### PR TITLE
Set the main window title to the PDF filename

### DIFF
--- a/run.pl
+++ b/run.pl
@@ -51,6 +51,14 @@ sub setup_window {
 
 	$self->setup_button_events;
 	$self->setup_drawing_area_example;
+
+	$self->setup_window_title;
+}
+
+sub setup_window_title {
+	my ($self) = @_;
+	my $mw = $self->builder->get_object('main_window');
+	$mw->set_title( $self->pdf_filename ) if defined $self->pdf_filename;
 }
 
 sub mudraw_get_image_surface_of_pdf_page_as_png {


### PR DESCRIPTION
Fixes #9.

Images from opening two different PDFs is attached:

![curie-title-00](https://cloud.githubusercontent.com/assets/94489/12968847/50c33d32-d03d-11e5-887c-708c0c5b044f.png)
![curie-title-01](https://cloud.githubusercontent.com/assets/94489/12968848/53e88ba2-d03d-11e5-9cfc-ea61eec9dc7d.png)
