### PR TITLE
Added text entry for setting and viewing page number.

### DIFF
--- a/curie.glade
+++ b/curie.glade
@@ -236,6 +236,17 @@
               </packing>
             </child>
             <child>
+              <object class="GtkEntry" id="page-number-entry">
+                <property name="visible">True</property>
+                <property name="can_focus">True</property>
+              </object>
+              <packing>
+                <property name="expand">True</property>
+                <property name="fill">True</property>
+                <property name="position">2</property>
+              </packing>
+            </child>
+            <child>
               <object class="GtkButton" id="button-forward">
                 <property name="label">gtk-go-forward</property>
                 <property name="visible">True</property>
@@ -247,7 +258,7 @@
               <packing>
                 <property name="expand">True</property>
                 <property name="fill">True</property>
-                <property name="position">2</property>
+                <property name="position">3</property>
               </packing>
             </child>
             <child>
@@ -262,7 +273,7 @@
               <packing>
                 <property name="expand">True</property>
                 <property name="fill">True</property>
-                <property name="position">3</property>
+                <property name="position">4</property>
               </packing>
             </child>
           </object>

--- a/run.pl
+++ b/run.pl
@@ -50,6 +50,7 @@ sub setup_window {
 	$self->builder->connect_signals;
 
 	$self->setup_button_events;
+	$self->setup_text_entry_events;
 	$self->setup_drawing_area_example;
 }
 
@@ -98,6 +99,7 @@ sub _trigger_pdf_filename {
 sub _trigger_pdf_current_page {
 	my ($self) = @_;
 	$self->refresh_drawing_area;
+
 }
 
 sub setup_button_events {
@@ -112,6 +114,23 @@ sub setup_button_events {
 		clicked => \&set_current_page_forward, $self );
 	$self->builder->get_object('button-back')->signal_connect(
 		clicked => \&set_current_page_back, $self );
+}
+
+sub setup_text_entry_events {
+	my ($self) = @_;
+
+	$self->builder->get_object('page-number-entry')->signal_connect(
+		activate => \&set_current_page_number, $self );
+}
+
+sub set_current_page_number {
+	my ($entry, $self) = @_;
+
+	my $text = $entry -> get_text;
+	if ($text =~ /^[0-9]+$/ and $text <= $self->pdf_last_page
+		 and $text >= $self->pdf_first_page){
+		$self->pdf_current_page( $text );
+	}
 }
 
 sub set_current_page_forward {
@@ -143,6 +162,10 @@ sub refresh_drawing_area {
 	return unless $self->drawing_area;
 
 	$self->drawing_area->queue_draw;
+
+	$self->builder->get_object('page-number-entry')
+		->set_text($self->pdf_current_page);
+
 }
 
 sub setup_drawing_area_example {


### PR DESCRIPTION
Added text entry using Glade. Setup the activate signal to use the
callback to set the page number. When the page number is changed,
the number in the entry field is changed to match the current page.
![screenshot from 2016-02-28 16 15 23](https://cloud.githubusercontent.com/assets/3936247/13382295/8aa7b260-de36-11e5-8af5-a5867b2e7ba1.png)
