### PR TITLE
Add Perl::Critic tests to Dist::Zilla

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,6 +8,8 @@ addons:
       - libpoppler-glib-dev
       - poppler-utils # pdfinfo
       - mupdf-tools   # mudraw
+      - aspell     # for dzil Test::PodSpelling
+      - aspell-en  # for dzil Test::PodSpelling
 perl:
   - "5.16"
   - "5.18"

--- a/bin/curie.pl
+++ b/bin/curie.pl
@@ -1,6 +1,7 @@
 #!/usr/bin/env perl
 # PODNAME: curie: a document reader
 
+use Modern::Perl;
 use FindBin;
 use lib "$FindBin::Bin/../lib";
 use Renard::Curie::App;

--- a/dist.ini
+++ b/dist.ini
@@ -22,6 +22,7 @@ Perl::Critic::Policy::CodeLayout::TabIndentSpaceAlign = 0
 [PodWeaver]
 [MinimumPerl]
 [RunExtraTests] ; run the xt/ tests
+[Test::PodSpelling]
 [Test::Perl::Critic]
 
 [ReadmeAnyFromPod / ReadmePodInRoot]

--- a/dist.ini
+++ b/dist.ini
@@ -10,12 +10,19 @@ version = 0.001
 -remove = ExtraTests
 
 [AutoPrereqs]
+[Prereqs / DevelopRequires]
+; For Test::Perl::Critic plugin
+Test::Perl::Critic = 0
+Perl::Critic::Policy::CodeLayout::TabIndentSpaceAlign = 0
+
+[MetaJSON]
 [PkgVersion]
 [CheckChangeLog]
 [GithubMeta]
 [PodWeaver]
 [MinimumPerl]
 [RunExtraTests] ; run the xt/ tests
+[Test::Perl::Critic]
 
 [ReadmeAnyFromPod / ReadmePodInRoot]
 ; generate README.pod in root (so that it can be displayed on GitHub)

--- a/lib/Renard/Curie.pm
+++ b/lib/Renard/Curie.pm
@@ -1,7 +1,5 @@
+use Modern::Perl;
 package Renard::Curie;
 # ABSTRACT: A document reader written with GTK+.
-
-use strict;
-use warnings;
 
 1;

--- a/lib/Renard/Curie/App.pm
+++ b/lib/Renard/Curie/App.pm
@@ -1,6 +1,5 @@
-package Renard::Curie::App;
-
 use Modern::Perl;
+package Renard::Curie::App;
 
 use Gtk3 -init;
 use Cairo;

--- a/lib/Renard/Curie/App.pm
+++ b/lib/Renard/Curie/App.pm
@@ -92,7 +92,7 @@ sub open_pdf_document {
 	# set window title
 	my $mw = $self->builder->get_object('main_window');
 	$mw->set_title( $pdf_filename );
-	
+
 	$self->open_document( $doc );
 }
 

--- a/lib/Renard/Curie/Component/PageDrawingArea.pm
+++ b/lib/Renard/Curie/Component/PageDrawingArea.pm
@@ -111,7 +111,7 @@ sub set_current_page_number {
 
 	my $text = $entry -> get_text;
 	if ($text =~ /^[0-9]+$/ and $text <= $self->document->last_page_number
-		 and $text >= $self->document->first_page_number){
+			and $text >= $self->document->first_page_number){
 		$self->current_page_number( $text );
 	}
 }

--- a/lib/Renard/Curie/Component/PageDrawingArea.pm
+++ b/lib/Renard/Curie/Component/PageDrawingArea.pm
@@ -1,6 +1,6 @@
+use Modern::Perl;
 package Renard::Curie::Component::PageDrawingArea;
 
-use Modern::Perl;
 use Moo;
 use Glib 'TRUE', 'FALSE';
 

--- a/lib/Renard/Curie/Data/PDF.pm
+++ b/lib/Renard/Curie/Data/PDF.pm
@@ -1,6 +1,6 @@
+use Modern::Perl;
 package Renard::Curie::Data::PDF;
 
-use Modern::Perl;
 use Capture::Tiny qw(capture_stdout);
 
 sub mudraw_get_pdf_page_as_png {

--- a/lib/Renard/Curie/Error.pm
+++ b/lib/Renard/Curie/Error.pm
@@ -1,6 +1,5 @@
-package Renard::Curie::Error;
-
 use Modern::Perl;
+package Renard::Curie::Error;
 
 use custom::failures qw/
 	IO::FileNotFound

--- a/lib/Renard/Curie/Helper.pm
+++ b/lib/Renard/Curie/Helper.pm
@@ -1,7 +1,7 @@
 use Modern::Perl;
 package Renard::Curie::Helper;
 
-sub gval ($$) {
+sub gval ($$) { ## no critic
 	# GValue wrapper shortcut
 	Glib::Object::Introspection::GValueWrapper->new('Glib::'.ucfirst($_[0]) => $_[1])
 }

--- a/lib/Renard/Curie/Helper.pm
+++ b/lib/Renard/Curie/Helper.pm
@@ -1,3 +1,4 @@
+use Modern::Perl;
 package Renard::Curie::Helper;
 
 sub gval ($$) {

--- a/lib/Renard/Curie/Model/CairoImageSurfaceDocument.pm
+++ b/lib/Renard/Curie/Model/CairoImageSurfaceDocument.pm
@@ -1,3 +1,4 @@
+use Modern::Perl;
 package Renard::Curie::Model::CairoImageSurfaceDocument;
 
 use Moo;

--- a/lib/Renard/Curie/Model/PDFDocument.pm
+++ b/lib/Renard/Curie/Model/PDFDocument.pm
@@ -1,3 +1,4 @@
+use Modern::Perl;
 package Renard::Curie::Model::PDFDocument;
 
 use Moo;

--- a/lib/Renard/Curie/Model/PDFDocument.pm
+++ b/lib/Renard/Curie/Model/PDFDocument.pm
@@ -61,12 +61,11 @@ rendered PDF page. This is C<1.0> by default.
 
 Optional. Value must be a Float.
 
-TODO : need to implement this option
 
 =back
 
 =cut
-
+# TODO : need to implement zoom_level option
 sub get_rendered_page {
 	my ($self, %opts) = @_;
 

--- a/lib/Renard/Curie/Model/RenderedDocumentPage.pm
+++ b/lib/Renard/Curie/Model/RenderedDocumentPage.pm
@@ -1,6 +1,6 @@
+use Modern::Perl;
 package Renard::Curie::Model::RenderedDocumentPage;
 
-use Modern::Perl;
 use Moo;
 use Path::Tiny;
 

--- a/perlcritic.rc
+++ b/perlcritic.rc
@@ -1,0 +1,10 @@
+theme = ( core + pbp + security + maintenance ) * bugs
+include = CodeLayout::ProhibitSpaceIndentation CodeLayout::ProhibitTrailingWhitespace CodeLayout::RequireConsistentNewlines CodeLayout::TabIndentSpaceAlign
+
+[TestingAndDebugging::RequireUseStrict]
+equivalent_modules = Modern::Perl Moo Moo::Role
+
+[TestingAndDebugging::RequireUseWarnings]
+equivalent_modules = Modern::Perl Moo Moo::Role
+
+# vim: ft=dosini


### PR DESCRIPTION
This should help prevent common mistakes including whitespace errors.

This addresses issue #46.
