### PR TITLE
Compatibility layer for older versions of GtkScrolledWindow's `add`

### DIFF
--- a/lib/Renard/Curie/App.pm
+++ b/lib/Renard/Curie/App.pm
@@ -11,6 +11,7 @@ use File::Basename;
 use Moo;
 
 use Renard::Curie::Error;
+use Renard::Curie::Helper;
 use Renard::Curie::Model::PDFDocument;
 use Renard::Curie::Component::PageDrawingArea;
 

--- a/lib/Renard/Curie/Component/PageDrawingArea.pm
+++ b/lib/Renard/Curie/Component/PageDrawingArea.pm
@@ -92,9 +92,7 @@ sub setup_drawing_area {
 	$scrolled_window->set_hexpand(TRUE);
 	$scrolled_window->set_vexpand(TRUE);
 
-	# XXX ->add_with_viewport( ... ) deprecated for Gtk v3.8+,
-	# use ->add( ... ) instead 
-	$scrolled_window->add_with_viewport($drawing_area);
+	$scrolled_window->add($drawing_area);
 	$scrolled_window->set_policy( 'automatic', 'automatic');
 
 	$vbox->pack_start( $scrolled_window, TRUE, TRUE, 0);

--- a/lib/Renard/Curie/Helper.pm
+++ b/lib/Renard/Curie/Helper.pm
@@ -1,6 +1,31 @@
 use Modern::Perl;
 package Renard::Curie::Helper;
 
+use Class::Method::Modifiers;
+
+sub import {
+	if( not Gtk3::CHECK_VERSION('3', '8', '0') ) {
+		# For versions of Gtk+ less than v3.8.0, we need to call
+		# `Gtk3::ScrolledWindow->add_with_viewport( ... )` so that the
+		# child widget gets placed in a viewport.
+		#
+		# Newer versions of Gtk+ automatically create the viewport when
+		# `Gtk3::ScrolledWindow->add( ... )` is called.
+		#
+		# See:
+		# - <https://developer.gnome.org/gtk3/3.6/GtkScrolledWindow.html>
+		# - <https://developer.gnome.org/gtk3/3.8/GtkScrolledWindow.html>
+		Class::Method::Modifiers::install_modifier
+			"Gtk3::ScrolledWindow",
+			around => add => sub {
+				my $orig = shift;
+				my $self = shift;
+				$self->add_with_viewport(@_);
+			};
+	}
+
+}
+
 sub gval ($$) { ## no critic
 	# GValue wrapper shortcut
 	Glib::Object::Introspection::GValueWrapper->new('Glib::'.ucfirst($_[0]) => $_[1])
@@ -10,3 +35,4 @@ sub genum {
 	Glib::Object::Introspection->convert_sv_to_enum($_[0], $_[1])
 }
 
+1;


### PR DESCRIPTION
This calls the `add_with_viewport` instead on versions of Gtk+ less than
v3.8.0. Newer versions of Gtk+ have deprecated this method in favour of
`add`.

Closes https://github.com/project-renard/curie/issues/42.
