### PR TITLE
Create a test library to share functions across tests

### DIFF
--- a/t/Renard/Curie/Component/PageDrawingArea.t
+++ b/t/Renard/Curie/Component/PageDrawingArea.t
@@ -1,51 +1,13 @@
-use Test::Most;
+use Test::Most tests => 3;
+
+use lib 't/lib';
+use CurieTestHelper;
 
 use Modern::Perl;
-use Renard::Curie::App;
-use Renard::Curie::Model::CairoImageSurfaceDocument;
-use Cairo;
 
-my $colors = [
-	[ 1, 0, 0 ],
-	[ 0, 1, 0 ],
-	[ 0, 0, 1 ],
-	[ 0, 0, 0 ],
-];
+my $cairo_doc = CurieTestHelper->create_cairo_document;
 
-my @surfaces = map {
-	my ($width, $height) = (100, 100);
-	my $surface = Cairo::ImageSurface->create(
-		'rgb24', $width, $height
-	);
-	my $cr = Cairo::Context->create( $surface );
-
-	my $rgb = $_;
-	$cr->set_source_rgb( @$rgb );
-	$cr->rectangle(0, 0, $width, $height);
-	$cr->fill;
-
-	$surface;
-} @$colors;
-
-my $cairo_doc = Renard::Curie::Model::CairoImageSurfaceDocument->new(
-	image_surfaces => \@surfaces,
-);
-
-sub build_test{
-	my ($callback) = @_;
-	return sub{
-		my $app = Renard::Curie::App->new;
-		$app->open_document( $cairo_doc );
-
-		my $page_comp = $app->page_document_component;
-
-		$callback->( $app, $page_comp );
-
-		$app->run;
-	}
-}
-
-subtest 'Check that moving forward changes the page number' => build_test ( sub {
+subtest 'Check that moving forward changes the page number' => CurieTestHelper->run_app_with_document($cairo_doc, sub {
 	my ( $app, $page_comp ) = @_;
 	my $forward_button = $page_comp->builder->get_object('button-forward');
 
@@ -65,7 +27,7 @@ subtest 'Check that moving forward changes the page number' => build_test ( sub 
 	});
 });
 
-subtest 'Check that the current button sensitivity is set on the first and last page' => build_test (sub {
+subtest 'Check that the current button sensitivity is set on the first and last page' => CurieTestHelper->run_app_with_document($cairo_doc, sub {
 	my ( $app, $page_comp ) = @_;
 
 	my $first_button = $page_comp->builder->get_object('button-first');
@@ -96,7 +58,7 @@ subtest 'Check that the current button sensitivity is set on the first and last 
 	});
 });
 
-subtest 'Check the number of pages label' => build_test ( sub {
+subtest 'Check the number of pages label' => CurieTestHelper->run_app_with_document($cairo_doc, sub {
 	my ( $app, $page_comp ) = @_;
 	my $number_of_pages_label;
 

--- a/t/lib/CurieTestHelper.pm
+++ b/t/lib/CurieTestHelper.pm
@@ -1,0 +1,126 @@
+use Modern::Perl;
+package CurieTestHelper;
+
+use Path::Tiny;
+
+use Renard::Curie::Model::CairoImageSurfaceDocument;
+use Cairo;
+
+use Renard::Curie::App;
+
+=func test_data_directory
+
+Returns a L<Path::Class> object that points to the path defined by
+the environment variable C<RENARD_TEST_DATA_PATH>.
+
+If the environment variable is not defined, throws an error.
+
+=cut
+sub test_data_directory {
+	my ($package) = @_;
+
+	if( not defined $ENV{RENARD_TEST_DATA_PATH} ) {
+		die "Must set environment variable RENARD_TEST_DATA_PATH to the path for the test-data repository";
+	}
+	return path( $ENV{RENARD_TEST_DATA_PATH} );
+}
+
+=func create_cairo_document
+
+Returns a L<Renard::Curie::Model::CairoImageSurfaceDocument> which can be
+used for testing.
+
+The pages have the colors:
+
+=for :list
+
+* red
+
+* green
+
+* blue
+
+* black
+
+=cut
+sub create_cairo_document {
+	my ($package) = @_;
+	my $colors = [
+		[ 1, 0, 0 ],
+		[ 0, 1, 0 ],
+		[ 0, 0, 1 ],
+		[ 0, 0, 0 ],
+	];
+
+	my @surfaces = map {
+		my ($width, $height) = (100, 100);
+		my $surface = Cairo::ImageSurface->create(
+			'rgb24', $width, $height
+		);
+		my $cr = Cairo::Context->create( $surface );
+
+		my $rgb = $_;
+		$cr->set_source_rgb( @$rgb );
+		$cr->rectangle(0, 0, $width, $height);
+		$cr->fill;
+
+		$surface;
+	} @$colors;
+
+	my $cairo_doc = Renard::Curie::Model::CairoImageSurfaceDocument->new(
+		image_surfaces => \@surfaces,
+	);
+}
+
+=func run_app_with_document
+
+  run_app_with_document( $document, $callback )
+
+Set up a L<Renard::Curie::App> application for running tests on a given
+document. The main loop of the L<Renard::Curie::App> application is run after
+the callback is called, so the callback should set up events to be run once the
+main loop has started.
+
+This callback set up can be accomplished by using L<Glib::Timeout>. For
+example, to run code 100 ms after the main loop has started, use:
+
+  Glib::Timeout->add(100, sub {
+    ...
+  });
+
+See the L<Glib documentation|https://developer.gnome.org/glib/stable/glib-The-Main-Event-Loop.html#g-timeout-add>
+for more information.
+
+=for :list
+
+* C<$document>:
+
+a document that will be opened by the L<Renard::Curie::App>
+
+* C<$callback>:
+
+a coderef which will be passed in the L<Renard::Curie::App> C<$app> and the
+current L<Renard::Curie::Component::PageDrawingArea> C<$page_component> for
+the document C<$document>.
+
+   sub {
+     my ( $app, $page_component ) = @_;
+     ...
+   }
+
+=cut
+sub run_app_with_document {
+	my ($package, $document, $callback) = @_;
+	return sub{
+		my $app = Renard::Curie::App->new;
+		$app->open_document( $document );
+
+		my $page_component = $app->page_document_component;
+
+		$callback->( $app, $page_component );
+
+		$app->run;
+	}
+}
+
+1;

--- a/xt/Renard/Curie/Model/PDFDocument.t
+++ b/xt/Renard/Curie/Model/PDFDocument.t
@@ -1,9 +1,19 @@
-use Test::Most tests => 1;
+use Test::Most;
 
-use Path::Tiny;
+use lib 't/lib';
+use CurieTestHelper;
+
+use Modern::Perl;
+use Try::Tiny;
 use Renard::Curie::Model::PDFDocument;
 
-my $pdf_ref_path = path( $ENV{RENARD_TEST_DATA_PATH}, qw(PDF Adobe pdf_reference_1-7.pdf) );
+my $pdf_ref_path = try {
+	CurieTestHelper->test_data_directory->child(qw(PDF Adobe pdf_reference_1-7.pdf));
+} catch {
+	plan skip_all => "$_";
+};
+
+plan tests => 1;
 
 subtest pdf_ref => sub {
 	my $pdf_doc = Renard::Curie::Model::PDFDocument->new(


### PR DESCRIPTION
This will make it easier to reuse common setup code and not have to
duplicate code such as error checking.
