### PR TITLE
Simplify the GUI testing by not starting the Gtk main loop

### DIFF
--- a/lib/Renard/Curie/App.pm
+++ b/lib/Renard/Curie/App.pm
@@ -91,8 +91,7 @@ sub open_pdf_document {
 	);
 
 	# set window title
-	my $mw = $self->builder->get_object('main-window');
-	$mw->set_title( $pdf_filename );
+	$self->window->set_title( $pdf_filename );
 
 	$self->open_document( $doc );
 }

--- a/lib/Renard/Curie/Component/PageDrawingArea.pm
+++ b/lib/Renard/Curie/Component/PageDrawingArea.pm
@@ -61,6 +61,8 @@ sub setup_button_events {
 		clicked => \&set_current_page_forward, $self );
 	$self->builder->get_object('button-back')->signal_connect(
 		clicked => \&set_current_page_back, $self );
+
+	$self->set_navigation_buttons_sensitivity;
 }
 
 sub setup_text_entry_events {

--- a/t/Renard/Curie/App.t
+++ b/t/Renard/Curie/App.t
@@ -1,0 +1,20 @@
+use Test::Most tests => 1;
+
+use lib 't/lib';
+use CurieTestHelper;
+
+use Try::Tiny;
+use Renard::Curie::App;
+
+subtest "Process arguments" => sub {
+	my $pdf_ref_path = try {
+		CurieTestHelper->test_data_directory->child(qw(PDF Adobe pdf_reference_1-7.pdf));
+	} catch {
+		plan skip_all => "$_";
+	};
+	local @ARGV = ($pdf_ref_path);
+	my $app = Renard::Curie::App->new;
+	$app->process_arguments;
+	like $app->window->get_title, qr/\Q$pdf_ref_path\E/, "Window title contains path to file";
+}
+

--- a/t/Renard/Curie/Component/PageDrawingArea.t
+++ b/t/Renard/Curie/Component/PageDrawingArea.t
@@ -7,28 +7,25 @@ use Modern::Perl;
 
 my $cairo_doc = CurieTestHelper->create_cairo_document;
 
-subtest 'Check that moving forward changes the page number' => CurieTestHelper->run_app_with_document($cairo_doc, sub {
-	my ( $app, $page_comp ) = @_;
+subtest 'Check that moving forward changes the page number' => sub {
+	my ($app, $page_comp) = CurieTestHelper->create_app_with_document($cairo_doc);
+
 	my $forward_button = $page_comp->builder->get_object('button-forward');
 
-	Glib::Timeout->add(100, sub {
-		is($page_comp->current_page_number, 1, 'Start on page 1' );
+	is($page_comp->current_page_number, 1, 'Start on page 1' );
 
-		$forward_button->clicked;
-		is($page_comp->current_page_number, 2, 'On page 2 after hitting forward' );
+	$forward_button->clicked;
+	is($page_comp->current_page_number, 2, 'On page 2 after hitting forward' );
 
-		$forward_button->clicked;
-		is($page_comp->current_page_number, 3, 'On page 3 after hitting forward' );
+	$forward_button->clicked;
+	is($page_comp->current_page_number, 3, 'On page 3 after hitting forward' );
 
-		$forward_button->clicked;
-		is($page_comp->current_page_number, 4, 'On page 4 after hitting forward' );
+	$forward_button->clicked;
+	is($page_comp->current_page_number, 4, 'On page 4 after hitting forward' );
+};
 
-		$app->window->destroy;
-	});
-});
-
-subtest 'Check that the current button sensitivity is set on the first and last page' => CurieTestHelper->run_app_with_document($cairo_doc, sub {
-	my ( $app, $page_comp ) = @_;
+subtest 'Check that the current button sensitivity is set on the first and last page' => sub {
+	my ($app, $page_comp) = CurieTestHelper->create_app_with_document($cairo_doc);
 
 	my $first_button = $page_comp->builder->get_object('button-first');
 	my $last_button = $page_comp->builder->get_object('button-last');
@@ -36,42 +33,35 @@ subtest 'Check that the current button sensitivity is set on the first and last 
 	my $forward_button = $page_comp->builder->get_object('button-forward');
 	my $back_button = $page_comp->builder->get_object('button-back');
 
-	Glib::Timeout->add(500, sub {
-		is($page_comp->current_page_number, 1, 'Start on page 1' );
+	is($page_comp->current_page_number, 1, 'Start on page 1' );
 
-		$page_comp->set_navigation_buttons_sensitivity;
+	ok ! $first_button->is_sensitive  , 'button-first is disabled on first page';
+	ok ! $back_button->is_sensitive   , 'button-back is disabled on first page';
+	ok   $last_button->is_sensitive   , 'button-last is enabled on first page';
+	ok   $forward_button->is_sensitive, 'button-forward is enabled on first page';
 
-		ok ! $first_button->is_sensitive  , 'button-first is disabled on first page';
-		ok ! $back_button->is_sensitive   , 'button-back is disabled on first page';
-		ok   $last_button->is_sensitive   , 'button-last is enabled on first page';
-		ok   $forward_button->is_sensitive, 'button-forward is enabled on first page';
+	$last_button->clicked;
 
-		$last_button->clicked;
-		is $page_comp->current_page_number, 4, 'On page 4 after hitting button-last';
+	is $page_comp->current_page_number, 4, 'On page 4 after hitting button-last';
 
-		$page_comp->set_navigation_buttons_sensitivity;
+	$page_comp->set_navigation_buttons_sensitivity;
 
-		ok   $first_button->is_sensitive  , 'button-first is enabled on last page';
-		ok   $back_button->is_sensitive   , 'button-back is enabled on last page';
-		ok ! $last_button->is_sensitive   , 'button-last is disabled on last page';
-		ok ! $forward_button->is_sensitive, 'button-forward is disabled on last page';
+	ok   $first_button->is_sensitive  , 'button-first is enabled on last page';
+	ok   $back_button->is_sensitive   , 'button-back is enabled on last page';
+	ok ! $last_button->is_sensitive   , 'button-last is disabled on last page';
+	ok ! $forward_button->is_sensitive, 'button-forward is disabled on last page';
+};
 
-		$app->window->destroy;
-	});
-});
+subtest 'Check the number of pages label' => sub {
+	my ($app, $page_comp) = CurieTestHelper->create_app_with_document($cairo_doc);
 
-subtest 'Check the number of pages label' => CurieTestHelper->run_app_with_document($cairo_doc, sub {
-	my ( $app, $page_comp ) = @_;
 	my $number_of_pages_label;
 
 	lives_ok {
 		$number_of_pages_label = $page_comp->builder->get_object("number-of-pages-label");
 	} 'The number of pages label exists';
 
-	Glib::Timeout->add(500, sub {
-			is( $number_of_pages_label->get_text() , '4', 'Number of pages should be equal to four.' );
-			$app->window->destroy;
-		});
-});
+	is( $number_of_pages_label->get_text() , '4', 'Number of pages should be equal to four.' );
+};
 
 done_testing;


### PR DESCRIPTION
This allows for running the tests synchronously and avoids using the
`Glib::Timeout` approach that introduces a delay and makes writing tests
that depend upon event propagation difficult.

Also adds a test of command line argument processing which closes #74.
