### PR TITLE
Add file filters to the "Open File" dialog

### DIFF
--- a/lib/Renard/Curie/App.pm
+++ b/lib/Renard/Curie/App.pm
@@ -15,6 +15,7 @@ use Renard::Curie::Helper;
 use Renard::Curie::Model::Document::PDF;
 use Renard::Curie::Component::PageDrawingArea;
 use Renard::Curie::Component::MenuBar;
+use Renard::Curie::Component::FileChooser;
 
 has window => ( is => 'lazy' );
 	sub _build_window {
@@ -112,25 +113,12 @@ sub open_document {
 	$pd->show_all;
 }
 
-sub get_open_file_dialog {
-	my ($self) = @_;
-
-	my $dialog = Gtk3::FileChooserDialog->new(
-		"Open File",
-		$self->window,
-		'GTK_FILE_CHOOSER_ACTION_OPEN',
-		'gtk-cancel' => 'cancel',
-		'gtk-open' => 'accept',
-	);
-
-	return $dialog;
-}
-
 # Callbacks {{{
 sub on_open_file_dialog_cb {
 	my ($self, $event) = @_;
 
-	my $dialog = $self->get_open_file_dialog;
+	my $file_chooser = Renard::Curie::Component::FileChooser->new( app => $self );
+	my $dialog = $file_chooser->get_open_file_dialog_with_filters;
 
 	my $result = $dialog->run;
 

--- a/lib/Renard/Curie/Component/FileChooser.pm
+++ b/lib/Renard/Curie/Component/FileChooser.pm
@@ -1,0 +1,57 @@
+use Modern::Perl;
+package Renard::Curie::Component::FileChooser;
+
+use Moo;
+
+has app => ( is => 'ro', required => 1, weak_ref => 1 );
+
+has all_filter => ( is => 'lazy' ); # _build_all_filter
+
+has pdf_filter => ( is => 'lazy' ); # _build_pdf_filter
+
+sub _build_all_filter {
+	my ($self) = @_;
+
+	my $filter = Gtk3::FileFilter->new();
+	$filter->set_name("All files");
+	$filter->add_pattern("*");
+
+	return $filter;
+}
+
+sub _build_pdf_filter {
+	my ($self) = @_;
+
+	my $filter = Gtk3::FileFilter->new();
+	$filter->set_name("PDF files");
+	$filter->add_mime_type("application/pdf");
+
+	return $filter;
+}
+
+sub get_open_file_dialog {
+	my ($self) = @_;
+
+	my $dialog = Gtk3::FileChooserDialog->new(
+		"Open File",
+		$self->app->window,
+		'GTK_FILE_CHOOSER_ACTION_OPEN',
+		'gtk-cancel' => 'cancel',
+		'gtk-open' => 'accept',
+	);
+
+	return $dialog;
+}
+
+sub get_open_file_dialog_with_filters {
+	my ($self) = @_;
+
+	my $dialog = $self->get_open_file_dialog;
+
+	$dialog->add_filter( $self->pdf_filter );
+	$dialog->add_filter( $self->all_filter );
+
+	return $dialog;
+}
+
+1;

--- a/t/Renard/Curie/Component/FileChooser.t
+++ b/t/Renard/Curie/Component/FileChooser.t
@@ -1,0 +1,23 @@
+use Test::Most tests => 1;
+
+use lib 't/lib';
+use CurieTestHelper;
+
+use Modern::Perl;
+use Renard::Curie::Component::FileChooser;
+
+subtest 'Check that the open file dialog with filters is created' => sub {
+	require Renard::Curie::App;
+	my $app = Renard::Curie::App->new;
+	my $file_chooser = Renard::Curie::Component::FileChooser->new( app => $app );
+
+	my $dialog = $file_chooser->get_open_file_dialog_with_filters;
+
+	is $dialog->get_title, 'Open File', 'Dialog has the right title';
+
+	my $filters = $dialog->list_filters;
+	my @filters_names = map { $_->get_name } @$filters;
+
+	cmp_deeply(\@filters_names, bag('All files', 'PDF files'),
+		'Has expected filters' );
+};


### PR DESCRIPTION
- The PDF file filter only shows files with the MIME type `application/pdf`.
- The All file filter matches all files
- Moved the dialog creation to a separate component.

Fixes https://github.com/project-renard/curie/issues/11.

![2016-05-29_07-11-47](https://cloud.githubusercontent.com/assets/94489/15633222/a5888884-256c-11e6-9e33-fd9cf5b299ea.gif)
