### PR TITLE
Make it possible to run curie under PAR::Packer

### DIFF
--- a/bin/curie.pl
+++ b/bin/curie.pl
@@ -1,6 +1,46 @@
 #!/usr/bin/env perl
 # PODNAME: curie: a document reader
 
+use strict;
+use warnings;
+
+BEGIN {
+	if( $^O eq 'MSWin32' && exists $ENV{PAR_PROGNAME} ) {
+		# running under PAR::Packer on Windows
+		require File::Basename;
+		require File::Spec;
+		require Config;
+		my $path_to_bin = File::Basename::dirname( $ENV{PAR_PROGNAME} );
+		my $mingw64_bin = File::Spec->catfile( $path_to_bin,
+				qw(mingw64 bin) );
+		my $dep_perl5lib = File::Spec->catfile( $path_to_bin,
+				qw(perl5 lib perl5) );
+		my $dep_arch_perl5lib = File::Spec->catfile( $path_to_bin,
+				qw(perl5 lib perl5 MSWin32-x64-multi-thread) );
+		my $core_perl5lib = File::Spec->catfile( $path_to_bin,
+				qw(mingw64 lib perl5 core_perl) );
+		my $app_perl5lib = File::Spec->catfile( $path_to_bin, qw(lib) );
+
+		$ENV{PATH} = "$mingw64_bin$Config::Config{path_sep}$ENV{PATH}";
+
+		unshift @INC, $core_perl5lib;
+		unshift @INC, $dep_perl5lib;
+		unshift @INC, $dep_arch_perl5lib;
+		unshift @INC, $app_perl5lib;
+
+		# Removes the persistent console window when compiled
+		# with /SUBSYSTEM:CONSOLE
+		print "Reticulating splines...\n";
+		require Win32::HideConsole;
+		Win32::HideConsole::hide_console();
+
+		# Removes the console windows for subprocesses that run under
+		# the cmd.exe shell when compiled with /SUBSYSTEM:WINDOWS
+		require Win32;
+		Win32::SetChildShowWindow(0);
+	}
+}
+
 use FindBin;
 use lib "$FindBin::Bin/../lib";
 use Renard::Curie::Setup;


### PR DESCRIPTION
This detects when the script is running under PAR::Packer and adds the
appropriate paths to Perl's include path. It also hides the console
under both /SUBSYSTEM:CONSOLE and /SUBSYSTEM:WINDOWS.

Also, we introduce temporary files to work around issues with `mutool`
and piping binary data to stdout on Windows. See https://github.com/project-renard/curie/issues/128
for more information.
