### PR TITLE
Rename all callback functions to the form on_*_cb

### DIFF
--- a/lib/Renard/Curie/App.pm
+++ b/lib/Renard/Curie/App.pm
@@ -58,9 +58,8 @@ method BUILD {
 
 	$self->setup_window;
 
-	$self->window->signal_connect( destroy => fun ($event, $self) {
-		$self->on_application_quit_cb($event);
-	}, $self );
+	$self->window->signal_connect(
+		destroy => \&on_application_quit_cb, $self );
 	$self->window->set_default_size( 800, 600 );
 }
 
@@ -111,7 +110,7 @@ method open_document( (DocumentModel) $doc ) {
 }
 
 # Callbacks {{{
-method on_open_file_dialog_cb( $event ) {
+fun on_open_file_dialog_cb( $event, $self ) {
 	my $file_chooser = Renard::Curie::Component::FileChooser->new( app => $self );
 	my $dialog = $file_chooser->get_open_file_dialog_with_filters;
 
@@ -126,7 +125,7 @@ method on_open_file_dialog_cb( $event ) {
 	}
 }
 
-method on_application_quit_cb( $event ) {
+fun on_application_quit_cb( $event, $self ) {
 	Gtk3::main_quit;
 }
 # }}}

--- a/lib/Renard/Curie/Component/PageDrawingArea.pm
+++ b/lib/Renard/Curie/Component/PageDrawingArea.pm
@@ -53,33 +53,37 @@ method BUILD {
 
 method setup_button_events() {
 	$self->builder->get_object('button-first')->signal_connect(
-		clicked =>
-			fun ($button, $self) {
-				$self->set_current_page_to_first;
-			}, $self );
+		clicked => \&on_activate_button_first_cb, $self );
 	$self->builder->get_object('button-last')->signal_connect(
-		clicked =>
-			fun ($button, $self) {
-				$self->set_current_page_to_last;
-			}, $self );
+		clicked => \&on_activate_button_last_cb, $self );
 
 	$self->builder->get_object('button-forward')->signal_connect(
-		clicked =>
-			fun ($button, $self) {
-				$self->set_current_page_forward;
-			}, $self );
+		clicked => \&on_activate_button_forward_cb, $self );
 	$self->builder->get_object('button-back')->signal_connect(
-		clicked =>
-			fun ($button, $self) {
-				$self->set_current_page_back;
-			}, $self );
+		clicked => \&on_activate_button_back_cb, $self );
 
 	$self->set_navigation_buttons_sensitivity;
 }
 
+fun on_activate_button_first_cb($button, $self) {
+	$self->set_current_page_to_first;
+}
+
+fun on_activate_button_last_cb($button, $self) {
+	$self->set_current_page_to_last;
+}
+
+fun on_activate_button_forward_cb($button, $self) {
+	$self->set_current_page_forward;
+}
+
+fun on_activate_button_back_cb($button, $self) {
+	$self->set_current_page_back;
+}
+
 method setup_text_entry_events() {
 	$self->builder->get_object('page-number-entry')->signal_connect(
-		activate => \&set_current_page_number, $self );
+		activate => \&on_activate_page_number_entry_cb, $self );
 }
 
 method setup_drawing_area() {
@@ -114,10 +118,10 @@ method setup_number_of_pages_label() {
 }
 
 method setup_keybindings() {
-	$self->signal_connect( key_press_event => \&key_pressed, $self );
+	$self->signal_connect( key_press_event => \&on_key_press_event_cb, $self );
 }
 
-fun key_pressed($window, $event, $self) {
+fun on_key_press_event_cb($window, $event, $self) {
 	if($event->keyval == Gtk3::Gdk::KEY_Page_Down){
 		$self->set_current_page_forward;
 	} elsif($event->keyval == Gtk3::Gdk::KEY_Page_Up){
@@ -169,7 +173,7 @@ method _trigger_current_page_number {
 	$self->refresh_drawing_area;
 }
 
-fun set_current_page_number( $entry, $self ) {
+fun on_activate_page_number_entry_cb( $entry, $self ) {
 	my $text = $entry -> get_text;
 	if ($text =~ /^[0-9]+$/ and $text <= $self->document->last_page_number
 			and $text >= $self->document->first_page_number) {

--- a/lib/Renard/Curie/Helper.pm
+++ b/lib/Renard/Curie/Helper.pm
@@ -44,4 +44,9 @@ classmethod genum( $package, $sv ) {
 	Glib::Object::Introspection->convert_sv_to_enum($package, $sv);
 }
 
+classmethod callback( $invocant, $callback_name, @args ) {
+	my $fun = $invocant->can( $callback_name );
+	$fun->( @args, $invocant );
+}
+
 1;

--- a/t/Renard/Curie/Component/FileChooser.t
+++ b/t/Renard/Curie/Component/FileChooser.t
@@ -6,6 +6,7 @@ use lib 't/lib';
 use CurieTestHelper;
 
 use Renard::Curie::Setup;
+use Renard::Curie::Helper;
 use Renard::Curie::App;
 use Renard::Curie::Component::FileChooser;
 use Test::MockModule;
@@ -43,7 +44,8 @@ subtest "Menu: File -> Open" => fun {
 		$fc->mock( run => 'accept' );
 
 		my $app = Renard::Curie::App->new;
-		$app->menu_bar->on_menu_file_open_activate_cb;
+		Renard::Curie::Helper->callback( $app->menu_bar,
+			on_menu_file_open_activate_cb => undef );
 
 		ok( $got_file, "Callback retrieved the filename");
 		ok( $destroyed, "Callback destroyed the dialog");
@@ -54,7 +56,8 @@ subtest "Menu: File -> Open" => fun {
 		$fc->mock( run => 'cancel' );
 
 		my $app = Renard::Curie::App->new;
-		$app->menu_bar->on_menu_file_open_activate_cb;
+		Renard::Curie::Helper->callback( $app->menu_bar,
+			on_menu_file_open_activate_cb => undef );
 		ok(!$got_file, "Callback did not retrieve the filename");
 		ok( $destroyed, "Callback destroyed the dialog");
 	};

--- a/t/Renard/Curie/Component/MenuBar.t
+++ b/t/Renard/Curie/Component/MenuBar.t
@@ -6,6 +6,7 @@ use lib 't/lib';
 use CurieTestHelper;
 
 use Renard::Curie::Setup;
+use Renard::Curie::Helper;
 use Gtk3;
 use URI::file;
 use List::AllUtils qw(first);
@@ -48,7 +49,8 @@ subtest "Menu: File -> Open" => fun {
 		$fc->mock( run => 'accept' );
 
 		my $app = Renard::Curie::App->new;
-		$app->menu_bar->on_menu_file_open_activate_cb;
+		Renard::Curie::Helper->callback( $app->menu_bar,
+			'on_menu_file_open_activate_cb', undef );
 
 		ok( $got_file, "Callback retrieved the filename");
 		ok( $destroyed, "Callback destroyed the dialog");
@@ -59,7 +61,8 @@ subtest "Menu: File -> Open" => fun {
 		$fc->mock( run => 'cancel' );
 
 		my $app = Renard::Curie::App->new;
-		$app->menu_bar->on_menu_file_open_activate_cb;
+		Renard::Curie::Helper->callback( $app->menu_bar,
+			'on_menu_file_open_activate_cb', undef );
 		ok(!$got_file, "Callback did not retrieve the filename");
 		ok( $destroyed, "Callback destroyed the dialog");
 	};


### PR DESCRIPTION
This makes their purpose clear and separates them from regular functions
of the view.

For example, `next_button_clicked` becomes `on_next_button_clicked_cb`.

This commit also turns all callbacks into functions rather than methods
(i.e., the first argument is not necessarily $self). This simplifies the
use of `signal_connect`.

Fixes https://github.com/project-renard/curie/issues/68.
