### PR TITLE
Refactor: Rename `on_activate_button_*` to `on_clicked_button_*`

### DIFF
--- a/lib/Renard/Curie/Component/PageDrawingArea.pm
+++ b/lib/Renard/Curie/Component/PageDrawingArea.pm
@@ -108,63 +108,63 @@ Sets up the signals for the navigational buttons.
 =cut
 method setup_button_events() {
 	$self->builder->get_object('button-first')->signal_connect(
-		clicked => \&on_activate_button_first_cb, $self );
+		clicked => \&on_clicked_button_first_cb, $self );
 	$self->builder->get_object('button-last')->signal_connect(
-		clicked => \&on_activate_button_last_cb, $self );
+		clicked => \&on_clicked_button_last_cb, $self );
 
 	$self->builder->get_object('button-forward')->signal_connect(
-		clicked => \&on_activate_button_forward_cb, $self );
+		clicked => \&on_clicked_button_forward_cb, $self );
 	$self->builder->get_object('button-back')->signal_connect(
-		clicked => \&on_activate_button_back_cb, $self );
+		clicked => \&on_clicked_button_back_cb, $self );
 
 	$self->set_navigation_buttons_sensitivity;
 }
 
-=callback on_activate_button_first_cb
+=callback on_clicked_button_first_cb
 
-  fun on_activate_button_first_cb($button, $self)
+  fun on_clicked_button_first_cb($button, $self)
 
 Callback for when the "First" button is pressed.
 See L</set_current_page_to_first>.
 
 =cut
-fun on_activate_button_first_cb($button, $self) {
+fun on_clicked_button_first_cb($button, $self) {
 	$self->set_current_page_to_first;
 }
 
-=callback on_activate_button_last_cb
+=callback on_clicked_button_last_cb
 
-  fun on_activate_button_last_cb($button, $self)
+  fun on_clicked_button_last_cb($button, $self)
 
 Callback for when the "Last" button is pressed.
 See L</set_current_page_to_last>.
 
 =cut
-fun on_activate_button_last_cb($button, $self) {
+fun on_clicked_button_last_cb($button, $self) {
 	$self->set_current_page_to_last;
 }
 
-=callback on_activate_button_forward_cb
+=callback on_clicked_button_forward_cb
 
-  fun on_activate_button_forward_cb($button, $self)
+  fun on_clicked_button_forward_cb($button, $self)
 
 Callback for when the "Forward" button is pressed.
 See L</set_current_page_forward>.
 
 =cut
-fun on_activate_button_forward_cb($button, $self) {
+fun on_clicked_button_forward_cb($button, $self) {
 	$self->set_current_page_forward;
 }
 
-=callback on_activate_button_back_cb
+=callback on_clicked_button_back_cb
 
-  fun on_activate_button_back_cb($button, $self)
+  fun on_clicked_button_back_cb($button, $self)
 
 Callback for when the "Back" button is pressed.
 See L</set_current_page_back>.
 
 =cut
-fun on_activate_button_back_cb($button, $self) {
+fun on_clicked_button_back_cb($button, $self) {
 	$self->set_current_page_back;
 }
 


### PR DESCRIPTION
This is so that the callback name matches the event name being handled.
