### PR TITLE
Make the navigation buttons be icons only

### DIFF
--- a/lib/Renard/Curie/Component/PageDrawingArea.glade
+++ b/lib/Renard/Curie/Component/PageDrawingArea.glade
@@ -1,7 +1,27 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<!-- Generated with glade 3.18.3 -->
+<!-- Generated with glade 3.20.0 -->
 <interface>
   <requires lib="gtk+" version="3.4"/>
+  <object class="GtkImage" id="gtk-go-back-stock">
+    <property name="visible">True</property>
+    <property name="can_focus">False</property>
+    <property name="stock">gtk-go-back</property>
+  </object>
+  <object class="GtkImage" id="gtk-go-forward-stock">
+    <property name="visible">True</property>
+    <property name="can_focus">False</property>
+    <property name="stock">gtk-go-forward</property>
+  </object>
+  <object class="GtkImage" id="gtk-goto-first-stock">
+    <property name="visible">True</property>
+    <property name="can_focus">False</property>
+    <property name="stock">gtk-goto-first</property>
+  </object>
+  <object class="GtkImage" id="gtk-goto-last-stock">
+    <property name="visible">True</property>
+    <property name="can_focus">False</property>
+    <property name="stock">gtk-goto-last</property>
+  </object>
   <object class="GtkBox" id="page-drawing-component">
     <property name="visible">True</property>
     <property name="can_focus">False</property>
@@ -13,12 +33,11 @@
         <property name="layout_style">center</property>
         <child>
           <object class="GtkButton" id="button-first">
-            <property name="label">gtk-goto-first</property>
             <property name="visible">True</property>
             <property name="can_focus">True</property>
             <property name="receives_default">True</property>
-            <property name="use_stock">True</property>
-            <property name="always_show_image">True</property>
+            <property name="tooltip_text" translatable="yes">First page</property>
+            <property name="image">gtk-goto-first-stock</property>
           </object>
           <packing>
             <property name="expand">True</property>
@@ -28,12 +47,11 @@
         </child>
         <child>
           <object class="GtkButton" id="button-back">
-            <property name="label">gtk-go-back</property>
             <property name="visible">True</property>
             <property name="can_focus">True</property>
             <property name="receives_default">True</property>
-            <property name="use_stock">True</property>
-            <property name="always_show_image">True</property>
+            <property name="tooltip_text" translatable="yes">Back a page</property>
+            <property name="image">gtk-go-back-stock</property>
           </object>
           <packing>
             <property name="expand">True</property>
@@ -66,12 +84,11 @@
         </child>
         <child>
           <object class="GtkButton" id="button-forward">
-            <property name="label">gtk-go-forward</property>
             <property name="visible">True</property>
             <property name="can_focus">True</property>
             <property name="receives_default">True</property>
-            <property name="use_stock">True</property>
-            <property name="always_show_image">True</property>
+            <property name="tooltip_text" translatable="yes">Forward a page</property>
+            <property name="image">gtk-go-forward-stock</property>
           </object>
           <packing>
             <property name="expand">True</property>
@@ -81,12 +98,11 @@
         </child>
         <child>
           <object class="GtkButton" id="button-last">
-            <property name="label">gtk-goto-last</property>
             <property name="visible">True</property>
             <property name="can_focus">True</property>
             <property name="receives_default">True</property>
-            <property name="use_stock">True</property>
-            <property name="always_show_image">True</property>
+            <property name="tooltip_text" translatable="yes">Last page</property>
+            <property name="image">gtk-goto-last-stock</property>
           </object>
           <packing>
             <property name="expand">True</property>


### PR DESCRIPTION
![-home-zaki-downloads-random_matrix_theory_innovative pdf 1 _430](https://cloud.githubusercontent.com/assets/94489/16552939/96961b86-418a-11e6-907c-f816bc05911a.png)

This uses stock icons from GTK without using button labels. Instead of
using button labels, we move the text to the tooltips.

This allows for a more balanced interface and takes up less room on the
screen.

Fixes https://github.com/project-renard/curie/issues/78.
