### PR TITLE
MenuBar: Change the page mode menu to use radio buttons

### DIFF
--- a/lib/Renard/Curie/Component/MenuBar.glade
+++ b/lib/Renard/Curie/Component/MenuBar.glade
@@ -176,31 +176,34 @@
                     <property name="visible">True</property>
                     <property name="can_focus">False</property>
                     <child>
-                      <object class="GtkCheckMenuItem" id="menu-item-view-pagemode-singlepage">
+                      <object class="GtkRadioMenuItem" id="menu-item-view-pagemode-singlepage">
                         <property name="visible">True</property>
                         <property name="can_focus">False</property>
                         <property name="label">Single page</property>
                       </object>
                     </child>
                     <child>
-                      <object class="GtkCheckMenuItem" id="menu-item-view-pagemode-facing-firstpagecenter">
+                      <object class="GtkRadioMenuItem" id="menu-item-view-pagemode-facing-firstpagecenter">
                         <property name="visible">True</property>
                         <property name="can_focus">False</property>
                         <property name="label">Facing pages (first page in center)</property>
+                        <property name="group">menu-item-view-pagemode-singlepage</property>
                       </object>
                     </child>
                     <child>
-                      <object class="GtkCheckMenuItem" id="menu-item-view-pagemode-facing-firstpageright">
+                      <object class="GtkRadioMenuItem" id="menu-item-view-pagemode-facing-firstpageright">
                         <property name="visible">True</property>
                         <property name="can_focus">False</property>
                         <property name="label">Facing pages (first page on right)</property>
+                        <property name="group">menu-item-view-pagemode-singlepage</property>
                       </object>
                     </child>
                     <child>
-                      <object class="GtkCheckMenuItem" id="menu-item-view-pagemode-facing-firstpageleft">
+                      <object class="GtkRadioMenuItem" id="menu-item-view-pagemode-facing-firstpageleft">
                         <property name="visible">True</property>
                         <property name="can_focus">False</property>
                         <property name="label">Facing pages (first page on left)</property>
+                        <property name="group">menu-item-view-pagemode-singlepage</property>
                       </object>
                     </child>
                   </object>

--- a/lib/Renard/Curie/Component/MenuBar.pm
+++ b/lib/Renard/Curie/Component/MenuBar.pm
@@ -5,6 +5,7 @@ package Renard::Curie::Component::MenuBar;
 use Moo;
 use URI;
 use Glib::Object::Subclass 'Gtk3::Bin';
+use Glib 'TRUE', 'FALSE';
 use Function::Parameters;
 use Renard::Curie::Types qw(InstanceOf);
 use Renard::Curie::Helper;
@@ -49,6 +50,7 @@ Initialises the menu bar signals.
 
 =cut
 method BUILD {
+	# File menu
 	$self->builder->get_object('menu-item-file-open')
 		->signal_connect( activate =>
 			\&on_menu_file_open_activate_cb, $self );
@@ -62,6 +64,12 @@ method BUILD {
 	$self->recent_chooser->signal_connect( 'item-activated' =>
 		\&on_menu_file_recentfiles_item_activated_cb, $self );
 
+
+	# View menu
+	$self->builder->get_object('menu-item-view-pagemode-singlepage')
+		->set_active(TRUE);
+
+	# Help menu
 	$self->builder->get_object('menu-item-help-logwin')
 		->signal_connect( activate =>
 			\&on_menu_help_logwin_activate_cb, $self );


### PR DESCRIPTION
This indicates that the modes are mutually exclusive.
![selection_433](https://cloud.githubusercontent.com/assets/94489/16961664/17564da6-4db4-11e6-861d-58f7fef6a404.png)
