### PR TITLE
Add outline component

### DIFF
--- a/cpanfile
+++ b/cpanfile
@@ -33,6 +33,7 @@ requires 'Types::Standard';
 requires 'URI';
 requires 'XML::Simple';
 requires 'autodie';
+requires 'autovivification';
 requires 'custom::failures';
 
 on test => sub {

--- a/dist.ini
+++ b/dist.ini
@@ -44,6 +44,7 @@ stopwords = Gtk
 stopwords = decrement
 stopwords = scrollbar
 stopwords = initialises
+stopwords = keybindings
 stopwords = mutool
 stopwords = MuPDF
 ; for Gtk3::Revealer

--- a/dist.ini
+++ b/dist.ini
@@ -55,6 +55,7 @@ stopwords = DocumentModel
 ; Types
 stopwords = GtkPackType
 stopwords = PageNumber
+stopwords = LaxPageNumber
 stopwords = RenderableDocumentModel
 stopwords = RenderablePageModel
 [PodCoverageTests]

--- a/dist.ini
+++ b/dist.ini
@@ -46,6 +46,8 @@ stopwords = scrollbar
 stopwords = initialises
 stopwords = mutool
 stopwords = MuPDF
+; for Gtk3::Revealer
+stopwords = revealer
 ; for the function name
 stopwords = FOREIGNBUILDARGS
 stopwords = DocumentModel

--- a/lib/Renard/Curie/App.pm
+++ b/lib/Renard/Curie/App.pm
@@ -64,9 +64,8 @@ has menu_bar => (
 
 =attr outline
 
-TODO
-
-A L<Renard::Curie::Component::Outline>
+A L<Renard::Curie::Component::Outline> which makes up the outline sidebar for
+this window.
 
 =cut
 has outline => (
@@ -86,7 +85,10 @@ has log_window => (
 
 =attr content_box
 
-TODO
+A horizontal L<Gtk3::Box> which is used to split the main application area into
+two different regions.
+
+The left region contains L</outline> and the right region contains L</page_document_component>.
 
 =cut
 has content_box => (

--- a/lib/Renard/Curie/App.pm
+++ b/lib/Renard/Curie/App.pm
@@ -16,6 +16,7 @@ use Renard::Curie::Component::Outline;
 use Renard::Curie::Component::MenuBar;
 use Renard::Curie::Component::LogWindow;
 use Renard::Curie::Component::FileChooser;
+use Renard::Curie::Component::AccelMap;
 
 use Log::Any::Adapter;
 
@@ -145,6 +146,8 @@ method setup_window() {
 	Log::Any::Adapter->set('+Renard::Curie::Log::Any::Adapter::LogWindow',
 		log_window => $log_win );
 	$self->log_window( $log_win );
+
+	Renard::Curie::Component::AccelMap->new( app => $self );
 }
 
 =method run

--- a/lib/Renard/Curie/Component/AccelMap.pm
+++ b/lib/Renard/Curie/Component/AccelMap.pm
@@ -1,0 +1,25 @@
+use Renard::Curie::Setup;
+package Renard::Curie::Component::AccelMap;
+# ABSTRACT: Set up the accelerator map (global keybindings)
+
+use Moo;
+use Function::Parameters;
+
+=method BUILD
+
+Constructor that sets up the keybindings for the default accelerator map.
+
+=cut
+method BUILD {
+	Gtk3::AccelMap::add_entry(
+		'<Curie-Main>/View/Sidebar',
+		Gtk3::Gdk::KEY_F9,
+		'release-mask'
+	);
+}
+
+with qw(
+	Renard::Curie::Component::Role::HasParentApp
+);
+
+1;

--- a/lib/Renard/Curie/Component/MenuBar.glade
+++ b/lib/Renard/Curie/Component/MenuBar.glade
@@ -2,6 +2,7 @@
 <!-- Generated with glade 3.20.0 -->
 <interface>
   <requires lib="gtk+" version="3.4"/>
+  <object class="GtkAccelGroup" id="menu-accel-group"/>
   <object class="GtkImage" id="menu-item-help-logwin-image">
     <property name="visible">True</property>
     <property name="can_focus">False</property>
@@ -20,6 +21,7 @@
           <object class="GtkMenu" id="menu-file">
             <property name="visible">True</property>
             <property name="can_focus">False</property>
+            <property name="accel_group">menu-accel-group</property>
             <child>
               <object class="GtkImageMenuItem" id="menu-item-file-new">
                 <property name="label">gtk-new</property>
@@ -98,6 +100,7 @@
           <object class="GtkMenu" id="menu-edit">
             <property name="visible">True</property>
             <property name="can_focus">False</property>
+            <property name="accel_group">menu-accel-group</property>
             <child>
               <object class="GtkImageMenuItem" id="menu-item-edit-cut">
                 <property name="label">gtk-cut</property>
@@ -152,6 +155,7 @@
           <object class="GtkMenu" id="menu-view">
             <property name="visible">True</property>
             <property name="can_focus">False</property>
+            <property name="accel_group">menu-accel-group</property>
             <child>
               <object class="GtkCheckMenuItem" id="menu-item-view-continuous">
                 <property name="visible">True</property>
@@ -214,9 +218,9 @@
               <object class="GtkCheckMenuItem" id="menu-item-view-sidebar">
                 <property name="visible">True</property>
                 <property name="can_focus">False</property>
+                <property name="accel_path">&lt;Curie-Main&gt;/View/Sidebar</property>
                 <property name="label">Side_bar</property>
                 <property name="use_underline">True</property>
-                <accelerator key="F9" signal="activate"/>
               </object>
             </child>
           </object>
@@ -233,6 +237,7 @@
           <object class="GtkMenu" id="menu-help">
             <property name="visible">True</property>
             <property name="can_focus">False</property>
+            <property name="accel_group">menu-accel-group</property>
             <child>
               <object class="GtkImageMenuItem" id="menu-item-help-logwin">
                 <property name="label">Message log</property>

--- a/lib/Renard/Curie/Component/MenuBar.glade
+++ b/lib/Renard/Curie/Component/MenuBar.glade
@@ -210,6 +210,15 @@
                 </child>
               </object>
             </child>
+            <child>
+              <object class="GtkCheckMenuItem" id="menu-item-view-sidebar">
+                <property name="visible">True</property>
+                <property name="can_focus">False</property>
+                <property name="label">Side_bar</property>
+                <property name="use_underline">True</property>
+                <accelerator key="F9" signal="activate"/>
+              </object>
+            </child>
           </object>
         </child>
       </object>

--- a/lib/Renard/Curie/Component/MenuBar.pm
+++ b/lib/Renard/Curie/Component/MenuBar.pm
@@ -69,6 +69,8 @@ method BUILD {
 	$self->builder->get_object('menu-item-view-pagemode-singlepage')
 		->set_active(TRUE);
 
+	# TODO Make sure that the menu-item-view-sidebar object matches
+	# the outline's revealer state.
 	$self->builder->get_object('menu-item-view-sidebar')
 		->signal_connect( toggled =>
 			\&on_menu_view_sidebar_cb, $self );
@@ -145,7 +147,9 @@ fun on_menu_help_logwin_activate_cb($event, $self) {
 
 =callback on_menu_view_sidebar_cb
 
-TODO
+Callback for the C<< View -> Sidebar >> menu item.
+
+This toggles whether or not the outline sidebar is visible.
 
 =cut
 fun on_menu_view_sidebar_cb($event_menu_item, $self) {

--- a/lib/Renard/Curie/Component/MenuBar.pm
+++ b/lib/Renard/Curie/Component/MenuBar.pm
@@ -50,6 +50,11 @@ Initialises the menu bar signals.
 
 =cut
 method BUILD {
+	# Accelerator group
+	$self->app->window->add_accel_group(
+		$self->builder->get_object('menu-accel-group')
+	);
+
 	# File menu
 	$self->builder->get_object('menu-item-file-open')
 		->signal_connect( activate =>

--- a/lib/Renard/Curie/Component/MenuBar.pm
+++ b/lib/Renard/Curie/Component/MenuBar.pm
@@ -69,6 +69,10 @@ method BUILD {
 	$self->builder->get_object('menu-item-view-pagemode-singlepage')
 		->set_active(TRUE);
 
+	$self->builder->get_object('menu-item-view-sidebar')
+		->signal_connect( toggled =>
+			\&on_menu_view_sidebar_cb, $self );
+
 	# Help menu
 	$self->builder->get_object('menu-item-help-logwin')
 		->signal_connect( activate =>
@@ -137,6 +141,15 @@ Displays the Message log window.
 =cut
 fun on_menu_help_logwin_activate_cb($event, $self) {
 	$self->app->log_window->show_log_window;
+}
+
+=callback on_menu_view_sidebar_cb
+
+TODO
+
+=cut
+fun on_menu_view_sidebar_cb($event_menu_item, $self) {
+	$self->app->outline->set_reveal_child( $event_menu_item->get_active );
 }
 
 # }}}

--- a/lib/Renard/Curie/Component/MenuBar.pm
+++ b/lib/Renard/Curie/Component/MenuBar.pm
@@ -153,7 +153,7 @@ This toggles whether or not the outline sidebar is visible.
 
 =cut
 fun on_menu_view_sidebar_cb($event_menu_item, $self) {
-	$self->app->outline->set_reveal_child( $event_menu_item->get_active );
+	$self->app->outline->reveal( $event_menu_item->get_active );
 }
 
 # }}}

--- a/lib/Renard/Curie/Component/MenuBar.pm
+++ b/lib/Renard/Curie/Component/MenuBar.pm
@@ -74,8 +74,13 @@ method BUILD {
 	$self->builder->get_object('menu-item-view-pagemode-singlepage')
 		->set_active(TRUE);
 
-	# TODO Make sure that the menu-item-view-sidebar object matches
-	# the outline's revealer state.
+	# Make sure that the menu-item-view-sidebar object matches
+	# the outline's revealer state once the application starts.
+	Glib::Timeout->add( 0, sub {
+		$self->builder->get_object('menu-item-view-sidebar')
+			->set_active($self->app->outline->get_reveal_child);
+		return FALSE; # run only once
+	});
 	$self->builder->get_object('menu-item-view-sidebar')
 		->signal_connect( toggled =>
 			\&on_menu_view_sidebar_cb, $self );

--- a/lib/Renard/Curie/Component/Outline.pm
+++ b/lib/Renard/Curie/Component/Outline.pm
@@ -5,7 +5,7 @@ package Renard::Curie::Component::Outline;
 use Moo;
 use Glib::Object::Subclass 'Gtk3::Revealer';
 use Glib 'TRUE', 'FALSE';
-use Renard::Curie::Types qw(InstanceOf);
+use Renard::Curie::Types qw(InstanceOf PageNumber);
 use Function::Parameters;
 
 =attr tree_view
@@ -124,7 +124,7 @@ fun on_tree_view_row_activate_cb( $tree_view, $path, $column, $self ) {
 	my $iter = $self->model->get_iter( $path );
 	my $page_num = $self->model->get_value($iter, 1);
 
-	$pd->current_page_number( $page_num );
+	PageNumber->check($page_num) and $pd->current_page_number( $page_num );
 }
 
 =method reveal

--- a/lib/Renard/Curie/Component/Outline.pm
+++ b/lib/Renard/Curie/Component/Outline.pm
@@ -1,0 +1,158 @@
+use Renard::Curie::Setup;
+package Renard::Curie::Component::Outline;
+
+# TODO
+# - Create an Model::Outline.
+# - Role for documents that have an outline.
+# - Sidebar list <https://metacpan.org/pod/Gtk3::SimpleList>.
+# - Make sure that the menu-item-view-sidebar object matches the state of the Revealer.
+use Moo;
+use Glib::Object::Subclass 'Gtk3::Revealer';
+use Glib 'TRUE', 'FALSE';
+use Function::Parameters;
+
+=attr tree_view
+
+TODO
+
+=cut
+has tree_view => (
+	is => 'rw'
+);
+
+=attr model
+
+TODO
+
+=cut
+has model => (
+	is => 'rw'
+);
+
+=classmethod FOREIGNBUILDARGS
+
+  classmethod FOREIGNBUILDARGS(@)
+
+Builds the L<Gtk3::Revealer> super-class.
+
+=cut
+classmethod FOREIGNBUILDARGS(@) {
+	return ();
+}
+
+=method BUILD
+
+TODO
+
+=cut
+method BUILD {
+	my $frame = Gtk3::Frame->new('Outline');
+	my $scrolled_window = Gtk3::ScrolledWindow->new;
+	$scrolled_window->set_vexpand(TRUE);
+	$scrolled_window->set_hexpand(TRUE);
+	$scrolled_window->set_policy( 'automatic', 'automatic');
+
+	$self->tree_view( Gtk3::TreeView->new );
+
+	my $data = Gtk3::TreeStore->new( 'Glib::String', 'Glib::String', );
+	$self->model( $data );
+
+	my $text_column = Gtk3::TreeViewColumn->new_with_attributes(
+		'Heading',
+		Gtk3::CellRendererText->new,
+		text => 0 );
+	my $page_number = Gtk3::TreeViewColumn->new_with_attributes(
+		'Page',
+		Gtk3::CellRendererText->new,
+		text => 1 );
+
+	$self->tree_view->insert_column($text_column, 0);
+	$self->tree_view->insert_column($page_number, 1);
+
+	$self->tree_view->set_model( $data );
+	$self->tree_view->set( 'headers-visible', FALSE );
+
+	$self->tree_view->signal_connect(
+		'row-activated' => \&on_tree_view_row_activate_cb, $self );
+
+	$self->set_transition_type( 'slide-right' );
+
+	$scrolled_window->add( $self->tree_view );
+	$frame->add( $scrolled_window );
+	$self->add( $frame );
+}
+
+=method update
+
+TODO
+
+=cut
+method update( $doc ) {
+	my $tree_view = $self->tree_view;
+	my $data = $self->model;
+
+	$data->clear;
+
+	return unless $doc->DOES('Renard::Curie::Model::Document::Role::Outlineable');
+	my $outline_items = $doc->outline->items;
+	my $level = 0;
+	my $iter = undef;
+	my @parents = ();
+	for my $item (@$outline_items) {
+		no autovivification;
+
+		# If we need to go up to the parent iterators.
+		while( @parents && $item->{level} < @parents ) {
+			$iter = pop @parents;
+		}
+
+		if( $item->{level} > @parents ) {
+			# If we need to go one level down to a child.
+			# NOTE : This is not a while(...) loop because the
+			# outline should only increase one level at a time.
+			push @parents, $iter;
+			$iter = $data->append($iter);
+			$level++;
+
+			# But if going down one level is not enough, this is a
+			# malformed outline. It should not be possible to go
+			# down multiple levels at a time.
+			if( $item->{level} > @parents ) {
+				die "Something went wrong with the outline data. It may be malformed."
+					." The level for the current item '@{[ $item->{text} ]}'"
+					." is @{[ $item->{level} ]},"
+					." but we are only at @{[ scalar @parents ]}."
+			}
+		} else {
+			# We are still at the same level. Just add a new row to
+			# that last parent (or undef if we are at the root).
+			$iter = $data->append( $parents[-1] // undef );
+		}
+
+		$data->set( $iter,
+			0 => $item->{text} // '',
+			1 => $item->{page} );
+	}
+}
+
+=callback on_tree_view_row_activate_cb
+
+TODO
+
+=cut
+fun on_tree_view_row_activate_cb( $tree_view, $path, $column, $self ) {
+	# NOTE : This needs more error checking.
+
+	my $pd = $self->app->page_document_component;
+
+	my $iter = $self->model->get_iter( $path );
+	my $page_num = $self->model->get_value($iter, 1);
+
+	$pd->current_page_number( $page_num );
+}
+
+with qw(
+	Renard::Curie::Component::Role::HasParentApp
+);
+
+1;

--- a/lib/Renard/Curie/Component/Outline.pm
+++ b/lib/Renard/Curie/Component/Outline.pm
@@ -1,32 +1,31 @@
 use Renard::Curie::Setup;
 package Renard::Curie::Component::Outline;
+# ABSTRACT: Component that provides a list of headings for navigating
 
-# TODO
-# - Create an Model::Outline.
-# - Role for documents that have an outline.
-# - Sidebar list <https://metacpan.org/pod/Gtk3::SimpleList>.
-# - Make sure that the menu-item-view-sidebar object matches the state of the Revealer.
 use Moo;
 use Glib::Object::Subclass 'Gtk3::Revealer';
 use Glib 'TRUE', 'FALSE';
+use Renard::Curie::Types qw(InstanceOf);
 use Function::Parameters;
 
 =attr tree_view
 
-TODO
+The L<Gtk3::TreeView> component that displays the interactive tree.
 
 =cut
 has tree_view => (
-	is => 'rw'
+	is => 'rw',
+	isa => InstanceOf['Gtk3::TreeView'],
 );
 
 =attr model
 
-TODO
+The L<Gtk3::TreeStore> that holds tree data of heading text and page numbers.
 
 =cut
 has model => (
-	is => 'rw'
+	is => 'rw',
+	isa => InstanceOf['Gtk3::TreeStore'],
 );
 
 =classmethod FOREIGNBUILDARGS
@@ -42,7 +41,10 @@ classmethod FOREIGNBUILDARGS(@) {
 
 =method BUILD
 
-TODO
+Constructor that sets up the view and model.
+
+This class is a subclass of L<Gtk3::Revealer> which allows the visible state to
+be toggled.
 
 =cut
 method BUILD {
@@ -84,7 +86,10 @@ method BUILD {
 
 =method update
 
-TODO
+  method update( $doc )
+
+Updates the outline's model to correspond to the outline of the currently
+displayed document.
 
 =cut
 method update( $doc ) {
@@ -137,7 +142,10 @@ method update( $doc ) {
 
 =callback on_tree_view_row_activate_cb
 
-TODO
+  fun on_tree_view_row_activate_cb( $tree_view, $path, $column, $self )
+
+Callback that navigates the current document to the position that corresponds
+to a row of the tree that has been clicked.
 
 =cut
 fun on_tree_view_row_activate_cb( $tree_view, $path, $column, $self ) {

--- a/lib/Renard/Curie/Component/Outline.pm
+++ b/lib/Renard/Curie/Component/Outline.pm
@@ -82,6 +82,7 @@ method BUILD {
 	$scrolled_window->add( $self->tree_view );
 	$frame->add( $scrolled_window );
 	$self->add( $frame );
+	$self->reveal( FALSE );
 }
 
 =method update
@@ -157,6 +158,23 @@ fun on_tree_view_row_activate_cb( $tree_view, $path, $column, $self ) {
 	my $page_num = $self->model->get_value($iter, 1);
 
 	$pd->current_page_number( $page_num );
+}
+
+=method reveal
+
+  method reveal( $should_reveal )
+
+Wrapper around the L<Gtk3::Revealer::set_reveal_child> method that sets the
+C<hexpand> property for this widget at the same time so that the parent
+container gives an appropriate amount of width to the widget.
+
+Without this, the revealer widget may still expand to take up some space when
+the child is not visible.
+
+=cut
+method reveal( $should_reveal ) {
+	$self->set( 'hexpand' => $should_reveal );
+	$self->set_reveal_child( $should_reveal );
 }
 
 with qw(

--- a/lib/Renard/Curie/Data/PDF.pm
+++ b/lib/Renard/Curie/Data/PDF.pm
@@ -247,45 +247,8 @@ fun get_mutool_page_info_xml($pdf_filename) {
   fun get_mutool_outline_simple($pdf_filename)
 
 Returns an array of the outline of the PDF file C<$pdf_filename> as an
-C<ArrayRef[HashRef]> where each C<HashRef> element is an element of the outline
-with the structure:
-
-  {
-    # The level in the outline that the item is at. Starts at zero (0).
-    level => PositiveOrZeroInt,
-
-    # The textual description of the item.
-    text  => Str,
-
-    # The page number that the outline item points to.
-    page  => PageNumber,
-  }
-
-A complete example is:
-
-  [
-    {
-      level => 0,
-      text  => 'Chapter 1',
-      page  => 20,
-    },
-    {
-      level => 1,
-      text  => 'Section 1.1',
-      page  => 25,
-    },
-    {
-      level => 0,
-      text  => 'Chapter 2',
-      page  => 30,
-    },
-  ]
-
-which represents the outline
-
-  Chapter 1 .......... 20
-    Section 1.1 ...... 25
-  Chapter 2 .......... 30
+C<ArrayRef[HashRef]> which corresponds to the C<items> attribute of
+L<Renard::Curie::Model::Outline>.
 
 =cut
 fun get_mutool_outline_simple($pdf_filename) {

--- a/lib/Renard/Curie/Data/PDF.pm
+++ b/lib/Renard/Curie/Data/PDF.pm
@@ -242,5 +242,71 @@ fun get_mutool_page_info_xml($pdf_filename) {
 	return $page_info;
 }
 
+=func get_mutool_outline_simple
+
+  fun get_mutool_outline_simple($pdf_filename)
+
+Returns an array of the outline of the PDF file C<$pdf_filename> as an
+C<ArrayRef[HashRef]> where each C<HashRef> element is an element of the outline
+with the structure:
+
+  {
+    # The level in the outline that the item is at. Starts at zero (0).
+    level => PositiveOrZeroInt,
+
+    # The textual description of the item.
+    text  => Str,
+
+    # The page number that the outline item points to.
+    page  => PageNumber,
+  }
+
+A complete example is:
+
+  [
+    {
+      level => 0,
+      text  => 'Chapter 1',
+      page  => 20,
+    },
+    {
+      level => 1,
+      text  => 'Section 1.1',
+      page  => 25,
+    },
+    {
+      level => 0,
+      text  => 'Chapter 2',
+      page  => 30,
+    },
+  ]
+
+which represents the outline
+
+  Chapter 1 .......... 20
+    Section 1.1 ...... 25
+  Chapter 2 .......... 30
+
+=cut
+fun get_mutool_outline_simple($pdf_filename) {
+	my $outline_text = _call_mutool(
+		qw(show),
+		$pdf_filename,
+		qw(outline)
+	);
+
+	my @outline_items = ();
+	open my $outline_fh, '<:encoding(UTF-8):crlf', \$outline_text;
+	while( defined( my $line = <$outline_fh> ) ) {
+		$line =~ /^(?<indent>\t*)(?<text>.*)\t(?<page>\d+)$/;
+		my %copy = %+;
+		$copy{level} = length $copy{indent};
+		delete $copy{indent};
+		push @outline_items, \%copy;
+	}
+
+	return \@outline_items;
+}
+
 
 1;

--- a/lib/Renard/Curie/Model/Document/PDF.pm
+++ b/lib/Renard/Curie/Model/Document/PDF.pm
@@ -5,6 +5,7 @@ package Renard::Curie::Model::Document::PDF;
 use Moo;
 use Renard::Curie::Data::PDF;
 use Renard::Curie::Model::Page::RenderedFromPNG;
+use Renard::Curie::Model::Outline;
 use Renard::Curie::Types qw(PageNumber);
 use Function::Parameters;
 
@@ -48,11 +49,20 @@ method get_rendered_page( (PageNumber) :$page_number ) {
 	);
 }
 
+method _build_outline {
+	my $outline_data = Renard::Curie::Data::PDF::get_mutool_outline_simple(
+		$self->filename
+	);
+
+	return Renard::Curie::Model::Outline->new( items => $outline_data );
+}
+
 with qw(
 	Renard::Curie::Model::Document::Role::FromFile
 	Renard::Curie::Model::Document::Role::Pageable
 	Renard::Curie::Model::Document::Role::Renderable
 	Renard::Curie::Model::Document::Role::Cacheable
+	Renard::Curie::Model::Document::Role::Outlineable
 );
 
 1;

--- a/lib/Renard/Curie/Model/Document/Role/Outlineable.pm
+++ b/lib/Renard/Curie/Model/Document/Role/Outlineable.pm
@@ -1,0 +1,18 @@
+use Renard::Curie::Setup;
+package Renard::Curie::Model::Document::Role::Outlineable;
+# ABSTRACT: TODO
+
+use Moo::Role;
+use Renard::Curie::Types qw(InstanceOf);
+
+=attr outline
+
+TODO
+
+=cut
+has outline => (
+	is => 'lazy', # _build_outline
+	isa => InstanceOf['Renard::Curie::Model::Outline'],
+);
+
+1;

--- a/lib/Renard/Curie/Model/Document/Role/Outlineable.pm
+++ b/lib/Renard/Curie/Model/Document/Role/Outlineable.pm
@@ -1,13 +1,14 @@
 use Renard::Curie::Setup;
 package Renard::Curie::Model::Document::Role::Outlineable;
-# ABSTRACT: TODO
+# ABSTRACT: Role that provides an outline for a document
 
 use Moo::Role;
 use Renard::Curie::Types qw(InstanceOf);
 
 =attr outline
 
-TODO
+Returns a L<Renard::Curie::Model::Outline> which represents the outline for
+this document.
 
 =cut
 has outline => (

--- a/lib/Renard/Curie/Model/Outline.pm
+++ b/lib/Renard/Curie/Model/Outline.pm
@@ -1,0 +1,19 @@
+use Renard::Curie::Setup;
+package Renard::Curie::Model::Outline;
+# ABSTRACT: TODO
+
+use Moo;
+use Renard::Curie::Types qw(ArrayRef HashRef);
+
+=attr items
+
+TODO
+
+=cut
+has items => (
+	is => 'rw',
+	required => 1,
+	isa => ArrayRef[HashRef],
+);
+
+1;

--- a/lib/Renard/Curie/Model/Outline.pm
+++ b/lib/Renard/Curie/Model/Outline.pm
@@ -5,7 +5,7 @@ package Renard::Curie::Model::Outline;
 use Moo;
 use Renard::Curie::Types qw(
 	ArrayRef Dict
-	PositiveOrZeroInt Str PageNumber
+	PositiveOrZeroInt Str LaxPageNumber
 	InstanceOf );
 use Type::Utils qw( declare as where message );
 
@@ -13,7 +13,7 @@ my $Outline = declare
 	as ArrayRef[Dict[
 			level => PositiveOrZeroInt,
 			text => Str,
-			page => PageNumber
+			page => LaxPageNumber
 		]];
 my $OutlineLevelCheck = declare
 	as $Outline,
@@ -53,7 +53,7 @@ Each C<HashRef> element is an element of the outline with the structure:
     text  => Str,
 
     # The page number that the outline item points to.
-    page  => PageNumber,
+    page  => LaxPageNumber,
   }
 
 A complete example is:

--- a/lib/Renard/Curie/Model/Outline.pm
+++ b/lib/Renard/Curie/Model/Outline.pm
@@ -1,13 +1,54 @@
 use Renard::Curie::Setup;
 package Renard::Curie::Model::Outline;
-# ABSTRACT: TODO
+# ABSTRACT: Model that represents a document outline
 
 use Moo;
 use Renard::Curie::Types qw(ArrayRef HashRef);
 
 =attr items
 
-TODO
+An C<ArrayRef[HashRef]> with a simple representation of an outline where each
+item of the ArrayRef represents an item in the list of headings displayed in
+order.
+
+Each C<HashRef> element is an element of the outline with the structure:
+
+  {
+    # The level in the outline that the item is at. Starts at zero (0).
+    level => PositiveOrZeroInt,
+
+    # The textual description of the item.
+    text  => Str,
+
+    # The page number that the outline item points to.
+    page  => PageNumber,
+  }
+
+A complete example is:
+
+  [
+    {
+      level => 0,
+      text  => 'Chapter 1',
+      page  => 20,
+    },
+    {
+      level => 1,
+      text  => 'Section 1.1',
+      page  => 25,
+    },
+    {
+      level => 0,
+      text  => 'Chapter 2',
+      page  => 30,
+    },
+  ]
+
+which represents the outline
+
+  Chapter 1 .......... 20
+    Section 1.1 ...... 25
+  Chapter 2 .......... 30
 
 =cut
 has items => (
@@ -15,5 +56,7 @@ has items => (
 	required => 1,
 	isa => ArrayRef[HashRef],
 );
+
+# TODO create the Gtk3::TreeStore here?
 
 1;

--- a/lib/Renard/Curie/Model/Outline.pm
+++ b/lib/Renard/Curie/Model/Outline.pm
@@ -3,7 +3,7 @@ package Renard::Curie::Model::Outline;
 # ABSTRACT: Model that represents a document outline
 
 use Moo;
-use Renard::Curie::Types qw(ArrayRef HashRef);
+use Renard::Curie::Types qw(ArrayRef HashRef InstanceOf);
 
 =attr items
 
@@ -57,6 +57,67 @@ has items => (
 	isa => ArrayRef[HashRef],
 );
 
-# TODO create the Gtk3::TreeStore here?
+=attr tree_store
+
+The L<Gtk3::TreeStore> representation for this outline. It holds tree data of
+the heading text and page numbers.
+
+=cut
+has tree_store => (
+	is => 'lazy', # _build_tree_store
+	isa => InstanceOf['Gtk3::TreeStore'],
+);
+
+
+method _build_tree_store {
+	# load Gtk3 dynamically if used outside Gtk3 context
+	require Gtk3;
+	Gtk3->import(qw(-init));
+
+	my $data = Gtk3::TreeStore->new( 'Glib::String', 'Glib::String', );
+
+	my $outline_items = $self->items;
+	my $level = 0;
+	my $iter = undef;
+	my @parents = ();
+
+	for my $item (@$outline_items) {
+		no autovivification;
+
+		# If we need to go up to the parent iterators.
+		while( @parents && $item->{level} < @parents ) {
+			$iter = pop @parents;
+		}
+
+		if( $item->{level} > @parents ) {
+			# If we need to go one level down to a child.
+			# NOTE : This is not a while(...) loop because the
+			# outline should only increase one level at a time.
+			push @parents, $iter;
+			$iter = $data->append($iter);
+			$level++;
+
+			# But if going down one level is not enough, this is a
+			# malformed outline. It should not be possible to go
+			# down multiple levels at a time.
+			if( $item->{level} > @parents ) {
+				die "Something went wrong with the outline data. It may be malformed."
+					." The level for the current item '@{[ $item->{text} ]}'"
+					." is @{[ $item->{level} ]},"
+					." but we are only at @{[ scalar @parents ]}."
+			}
+		} else {
+			# We are still at the same level. Just add a new row to
+			# that last parent (or undef if we are at the root).
+			$iter = $data->append( $parents[-1] // undef );
+		}
+
+		$data->set( $iter,
+			0 => $item->{text} // '',
+			1 => $item->{page} );
+	}
+
+	$data;
+}
 
 1;

--- a/lib/Renard/Curie/Types.pm
+++ b/lib/Renard/Curie/Types.pm
@@ -13,7 +13,7 @@ use Type::Utils -all;
 # Listed here so that scan-perl-deps can find them
 use Types::Path::Tiny      ();
 use Types::Standard        ();
-use Types::Common::Numeric qw(PositiveInt);
+use Types::Common::Numeric qw(PositiveInt PositiveOrZeroInt);
 
 use Type::Libraries;
 Type::Libraries->setup_class(
@@ -66,5 +66,13 @@ An alias to L<PositiveInt> that can be used for document page number semantics.
 
 =cut
 declare "PageNumber", parent => PositiveInt;
+
+=type LaxPageNumber
+
+An alias to L<PositiveOrZeroInt> that can be used for document page number
+semantics when the source data may contain invalid pages.
+
+=cut
+declare "LaxPageNumber", parent => PositiveOrZeroInt;
 
 1;

--- a/lib/Renard/Curie/Types.pm
+++ b/lib/Renard/Curie/Types.pm
@@ -8,13 +8,12 @@ use Type::Library 0.008 -base,
 		RenderableDocumentModel
 		PageNumber
 	)];
-use Type::Utils;
-use Types::Common::Numeric qw(PositiveInt);
+use Type::Utils -all;
 
 # Listed here so that scan-perl-deps can find them
 use Types::Path::Tiny      ();
 use Types::Standard        ();
-use Types::Common::Numeric ();
+use Types::Common::Numeric qw(PositiveInt);
 
 use Type::Libraries;
 Type::Libraries->setup_class(
@@ -66,6 +65,6 @@ role_type "RenderablePageModel",
 An alias to L<PositiveInt> that can be used for document page number semantics.
 
 =cut
-declare "PageNumber", as => PositiveInt;
+declare "PageNumber", parent => PositiveInt;
 
 1;

--- a/t/Renard/Curie/Component/MenuBar.t
+++ b/t/Renard/Curie/Component/MenuBar.t
@@ -1,6 +1,6 @@
 #!/usr/bin/env perl
 
-use Test::Most tests => 5;
+use Test::Most tests => 6;
 
 use lib 't/lib';
 use CurieTestHelper;
@@ -107,6 +107,21 @@ subtest "Menu: File -> Recent files" => fun {
 	$rc->signal_emit('item-activated');
 
 	is path($app->page_document_component->document->filename), $pdf_ref_path, 'File opened from Recent files';
+};
+
+subtest "Menu: View -> Sidebar" => fun {
+	plan tests => 1;
+	my $app = Renard::Curie::App->new;
+
+	my $initial_outline_reveal = $app->outline->get_reveal_child;
+
+	$app->menu_bar->builder
+		->get_object('menu-item-view-sidebar')
+		->signal_emit('activate');
+
+	my $post_outline_reveal = $app->outline->get_reveal_child;
+	isnt( $post_outline_reveal, $initial_outline_reveal,
+		'outline reveal state has been toggled' );
 };
 
 subtest "Menu: Help -> Message log" => fun {

--- a/t/Renard/Curie/Component/Outline.t
+++ b/t/Renard/Curie/Component/Outline.t
@@ -17,48 +17,14 @@ my $pdf_ref_path = try {
 
 plan tests => 1;
 
-fun print_tree_store($store, $callback) {
-    walk_tree_store($store, fun( $level, $data ) {
-	say "\t"x$level . join ":", @$data;
-    });
-}
-
-fun walk_tree_store($store, $callback) {
-    my $rootiter = $store->get_iter_first();
-    walk_rows($store, $rootiter, 0, $callback);
-}
-
-fun walk_rows($store, $treeiter, $level, $callback) {
-	my $valid = 1;
-	while($valid) {
-		my @array = $store->get( $treeiter, 0 .. $store->get_n_columns - 1);
-		$callback->( $level, \@array );
-		if( $store->iter_has_child($treeiter) ) {
-			my $childiter = $store->iter_children($treeiter);
-			walk_rows($store, $childiter, $level + 1, $callback);
-		}
-		$valid = $store->iter_next($treeiter);
-	}
-}
-
-subtest 'Check that moving forward and backward changes the page number' => fun {
+subtest 'Check that the outline model is set for the current document' => fun {
 	my $app = Renard::Curie::App->new;
 	$app->open_pdf_document( $pdf_ref_path );
 	my $doc = $app->page_document_component->document;
 	my $outline = $doc->outline;
 
-	#print_tree_store($app->outline->model);
-	my $tree_store_data = [];
-	walk_tree_store( $app->outline->model, fun($level, $data ) {
-		push @$tree_store_data,
-			{
-				level => $level,
-				text => $data->[0],
-				page => $data->[1],
-			};
-	});
-	is_deeply( $tree_store_data, $outline->items,
-		'Outline tree store matches outline data');
+	is( $app->outline->model, $outline->tree_store,
+		"The outline component's model is set to the document's outline model");
 };
 
 done_testing;

--- a/t/Renard/Curie/Component/Outline.t
+++ b/t/Renard/Curie/Component/Outline.t
@@ -15,7 +15,7 @@ my $pdf_ref_path = try {
 	plan skip_all => "$_";
 };
 
-plan tests => 1;
+plan tests => 2;
 
 subtest 'Check that the outline model is set for the current document' => fun {
 	my $app = Renard::Curie::App->new;
@@ -25,6 +25,30 @@ subtest 'Check that the outline model is set for the current document' => fun {
 
 	is( $app->outline->model, $outline->tree_store,
 		"The outline component's model is set to the document's outline model");
+};
+
+subtest 'Check that clicking an outline item sets the page number' => fun {
+	plan tests => 3;
+
+	my $app = Renard::Curie::App->new;
+	$app->open_pdf_document( $pdf_ref_path );
+	my $page_comp = $app->page_document_component;
+	my $doc = $app->page_document_component->document;
+	my $outline = $doc->outline;
+
+	# start on first page
+	$app->page_document_component->current_page_number(1);
+	is $page_comp->current_page_number, 1, "Start off on the first page";
+
+	my $path_to_second_item = Gtk3::TreePath->new_from_indices(1);
+	my $first_column = $app->outline->tree_view->get_column(0);
+	$app->outline->tree_view->row_activated( $path_to_second_item, $first_column );
+
+	my $second_outline_item_page = $outline->items->[1]{page};
+
+	is $second_outline_item_page, 9, 'Second outline item page number is 9';
+	is $page_comp->current_page_number, $second_outline_item_page,
+		"Activating the second outline row sets the correct page number";
 };
 
 done_testing;

--- a/t/Renard/Curie/Component/Outline.t
+++ b/t/Renard/Curie/Component/Outline.t
@@ -1,0 +1,64 @@
+#!/usr/bin/env perl
+
+use Test::Most;
+
+use lib 't/lib';
+use CurieTestHelper;
+
+use Renard::Curie::Setup;
+use Renard::Curie::App;
+use Function::Parameters;
+
+my $pdf_ref_path = try {
+	CurieTestHelper->test_data_directory->child(qw(PDF Adobe pdf_reference_1-7.pdf));
+} catch {
+	plan skip_all => "$_";
+};
+
+plan tests => 1;
+
+fun print_tree_store($store, $callback) {
+    walk_tree_store($store, fun( $level, $data ) {
+	say "\t"x$level . join ":", @$data;
+    });
+}
+
+fun walk_tree_store($store, $callback) {
+    my $rootiter = $store->get_iter_first();
+    walk_rows($store, $rootiter, 0, $callback);
+}
+
+fun walk_rows($store, $treeiter, $level, $callback) {
+	my $valid = 1;
+	while($valid) {
+		my @array = $store->get( $treeiter, 0 .. $store->get_n_columns - 1);
+		$callback->( $level, \@array );
+		if( $store->iter_has_child($treeiter) ) {
+			my $childiter = $store->iter_children($treeiter);
+			walk_rows($store, $childiter, $level + 1, $callback);
+		}
+		$valid = $store->iter_next($treeiter);
+	}
+}
+
+subtest 'Check that moving forward and backward changes the page number' => fun {
+	my $app = Renard::Curie::App->new;
+	$app->open_pdf_document( $pdf_ref_path );
+	my $doc = $app->page_document_component->document;
+	my $outline = $doc->outline;
+
+	#print_tree_store($app->outline->model);
+	my $tree_store_data = [];
+	walk_tree_store( $app->outline->model, fun($level, $data ) {
+		push @$tree_store_data,
+			{
+				level => $level,
+				text => $data->[0],
+				page => $data->[1],
+			};
+	});
+	is_deeply( $tree_store_data, $outline->items,
+		'Outline tree store matches outline data');
+};
+
+done_testing;

--- a/t/Renard/Curie/Data/PDF.t
+++ b/t/Renard/Curie/Data/PDF.t
@@ -16,7 +16,7 @@ my $pdf_ref_path = try {
 	plan skip_all => "$_";
 };
 
-plan tests => 3;
+plan tests => 4;
 
 subtest 'PDF page to PNG' => fun {
 	my $png_data = Renard::Curie::Data::PDF::get_mutool_pdf_page_as_png( $pdf_ref_path, 1 );
@@ -46,6 +46,17 @@ subtest 'Get characters for preface' => fun {
 	like( $text_concat,
 		qr/The origins of the Portable Document Format/,
 		'Page text contains expected substring' );
+};
+
+subtest 'Get outline of PDF document' => fun {
+	my $outline_data = Renard::Curie::Data::PDF::get_mutool_outline_simple( $pdf_ref_path );
+
+	cmp_deeply $outline_data,
+		superbagof({
+			level => 2,
+			text => '1.2.6 General Features',
+			page => 31 }),
+		'has expected outline item';
 };
 
 done_testing;

--- a/t/Renard/Curie/Model/Outline.t
+++ b/t/Renard/Curie/Model/Outline.t
@@ -1,0 +1,63 @@
+#!/usr/bin/env perl
+
+use Test::Most;
+
+use lib 't/lib';
+use CurieTestHelper;
+
+use Renard::Curie::Setup;
+use Renard::Curie::Model::Document::PDF;
+use Function::Parameters;
+
+my $pdf_ref_path = try {
+	CurieTestHelper->test_data_directory->child(qw(PDF Adobe pdf_reference_1-7.pdf));
+} catch {
+	plan skip_all => "$_";
+};
+
+plan tests => 1;
+
+fun print_tree_store($store, $callback) {
+    walk_tree_store($store, fun( $level, $data ) {
+	say "\t"x$level . join ":", @$data;
+    });
+}
+
+fun walk_tree_store($store, $callback) {
+    my $rootiter = $store->get_iter_first();
+    walk_rows($store, $rootiter, 0, $callback);
+}
+
+fun walk_rows($store, $treeiter, $level, $callback) {
+	my $valid = 1;
+	while($valid) {
+		my @array = $store->get( $treeiter, 0 .. $store->get_n_columns - 1);
+		$callback->( $level, \@array );
+		if( $store->iter_has_child($treeiter) ) {
+			my $childiter = $store->iter_children($treeiter);
+			walk_rows($store, $childiter, $level + 1, $callback);
+		}
+		$valid = $store->iter_next($treeiter);
+	}
+}
+
+subtest 'Check that the tree store matches the items' => fun {
+	my $doc = Renard::Curie::Model::Document::PDF
+		->new( filename => $pdf_ref_path );
+	my $outline = $doc->outline;
+
+	#print_tree_store($app->outline->model);
+	my $tree_store_data = [];
+	walk_tree_store( $outline->tree_store, fun($level, $data ) {
+		push @$tree_store_data,
+			{
+				level => $level,
+				text => $data->[0],
+				page => $data->[1],
+			};
+	});
+	is_deeply( $tree_store_data, $outline->items,
+		'Outline tree store matches outline items');
+};
+
+done_testing;

--- a/t/Renard/Curie/Model/Outline.t
+++ b/t/Renard/Curie/Model/Outline.t
@@ -6,6 +6,7 @@ use lib 't/lib';
 use CurieTestHelper;
 
 use Renard::Curie::Setup;
+use Renard::Curie::Model::Outline;
 use Renard::Curie::Model::Document::PDF;
 use Function::Parameters;
 
@@ -15,7 +16,7 @@ my $pdf_ref_path = try {
 	plan skip_all => "$_";
 };
 
-plan tests => 1;
+plan tests => 2;
 
 fun print_tree_store($store, $callback) {
     walk_tree_store($store, fun( $level, $data ) {
@@ -40,6 +41,46 @@ fun walk_rows($store, $treeiter, $level, $callback) {
 		$valid = $store->iter_next($treeiter);
 	}
 }
+
+subtest 'Outline item type-checking' => fun {
+	my @valid_outlines = (
+		[
+			{ level => 0, text  => 'Chapter 1', page  => 20, },
+			{ level => 1, text  => 'Section 1.1', page  => 25, },
+			{ level => 0, text  => 'Chapter 2', page  => 30, },
+		]
+	);
+
+	my @invalid_outlines = (
+		# level increase greater than one level
+		[
+			{ level => 0, text  => 'Chapter 1', page  => 20, },
+			{ level => 2, text  => 'Section 1.1', page  => 25, },
+			{ level => 0, text  => 'Chapter 2', page  => 30, },
+		],
+		# problem with page number
+		[
+			{ level => 0, text  => 'Chapter 1', page  => 0, },
+		]
+	);
+	my @invalid_message = (
+		qr/malformed/,
+		qr/PageNumber/,
+	);
+
+	plan tests => @valid_outlines + @invalid_outlines;
+
+	lives_ok {
+		Renard::Curie::Model::Outline->new( items => $_ );
+	} 'Valid outline check' for @valid_outlines;
+
+	for (0..@invalid_outlines-1) {
+		throws_ok {
+			Renard::Curie::Model::Outline->new(
+				items => $invalid_outlines[$_] );
+			} $invalid_message[$_], 'Invalid outline exception';
+	}
+};
 
 subtest 'Check that the tree store matches the items' => fun {
 	my $doc = Renard::Curie::Model::Document::PDF

--- a/t/Renard/Curie/Model/Outline.t
+++ b/t/Renard/Curie/Model/Outline.t
@@ -60,7 +60,7 @@ subtest 'Outline item type-checking' => fun {
 		],
 		# problem with page number
 		[
-			{ level => 0, text  => 'Chapter 1', page  => 0, },
+			{ level => 0, text  => 'Chapter 1', page  => -1, },
 		]
 	);
 	my @invalid_message = (


### PR DESCRIPTION
## READY FOR REVIEW
### TODO
- [x] Read the outline data from `mutool`.
- [x] Create a model for storing outline representation.
- [x] Create the `Gtk3::TreeView` and `Gtk3::TreeStore` to display outline.
- [x] Documentation.
- [x] Move the `Gtk3::TreeStore` model creation to the outline model rather than outline component.
- [x] Add outline model error checking for malformed outlines to the type-checker.
- [x] Make the `F9` accelerator map work.
- [x] Make sure that the menu item for toggling the sidebar matches the state of the outline component.
- [x] Make sure coverage remains at 100%.

---

![out](https://cloud.githubusercontent.com/assets/94489/17046088/522e2b5a-4f95-11e6-82ba-f03be58fabf2.gif)

---

This reworks the main area of the application so that it can display
both the document and an outline of the same document.

The application now contains a horizontal box that contains:

```
Box (horizontal)
|_ Revealer        (used to show/hide the TreeView)
|  |_ TreeView     (contains the outline items)
|_ PageDrawingArea (contains the document images)
```

The outline can be hidden and displayed via a menu item that toggles the
revealer to show its child.

---

PDF: extract PDF outline using mutool

---

Fixes https://github.com/project-renard/curie/issues/145.

![-home-zaki-sw_projects-project-renard-test-data-test-data-pdf-adobe-pdf_reference_1-7 pdf 1 _434](https://cloud.githubusercontent.com/assets/94489/17042953/ebe501ec-4f77-11e6-89b7-623d5e23c090.png)
