### PR TITLE
LogWindow: Check for monospace property for Gtk3::TextView

### DIFF
--- a/lib/Renard/Curie/Component/LogWindow.glade
+++ b/lib/Renard/Curie/Component/LogWindow.glade
@@ -41,7 +41,6 @@
                 <property name="can_focus">True</property>
                 <property name="editable">False</property>
                 <property name="wrap_mode">word</property>
-                <property name="monospace">True</property>
               </object>
             </child>
           </object>

--- a/lib/Renard/Curie/Component/LogWindow.pm
+++ b/lib/Renard/Curie/Component/LogWindow.pm
@@ -39,6 +39,12 @@ Initialises the logging window.
 
 =cut
 method BUILD {
+	my $log_textview = $self->builder->get_object('log-text');
+	if( $log_textview->can('set_monospace') ) {
+		$log_textview->set_monospace(TRUE);
+	} else {
+		warn('Gtk3::TextView monospace property not available for Gtk+ < v3.16.');
+	}
 	$self->builder->get_object('log-window')
 		->signal_connect(
 			'delete-event'


### PR DESCRIPTION
Older versions of libgtk3 do not support the 'monospace' property, so we
check if it exists so that the application can work on Gtk+ < v3.16.
Since the property is only cosmetic, this is just a warning.
