### PR TITLE
Set custom theme and icon theme if available

### DIFF
--- a/lib/Renard/Curie/Helper.pm
+++ b/lib/Renard/Curie/Helper.pm
@@ -8,11 +8,12 @@ package Renard::Curie::Helper;
 
 =cut
 
+use Renard::Curie::Types qw(Str);
 use Class::Method::Modifiers;
 use Gtk3;
 use Function::Parameters;
 
-fun import {
+fun _scrolled_window_viewport_shim() {
 	# Note: The code below is marked as uncoverable because it only applies
 	# to a single version of GTK+ and thus is not part of the general
 	# coverage. The functionality that it adds is tested in other ways.
@@ -37,7 +38,51 @@ fun import {
 				$self->add_with_viewport(@_); # uncoverable statement
 			};                                    # uncoverable statement
 	}
+}
 
+fun _can_set_theme {
+	# uncoverable branch true
+	return $^O ne 'MSWin32' && Gtk3::CHECK_VERSION('3', '20', '1');
+}
+
+fun _set_theme( (Str) $theme_name ) {
+	# uncoverable subroutine
+	# uncoverable branch true
+	return unless _can_set_theme;
+
+	my $adwaita = Gtk3::CssProvider::get_named('Adawaita')->to_string;  # uncoverable statement
+	my $custom = Gtk3::CssProvider::get_named($theme_name)->to_string;  # uncoverable statement
+	if( $adwaita ne $custom ) {                                         # uncoverable statement
+		my $settings = Gtk3::Settings::get_default;                 # uncoverable statement
+		$settings->set_property('gtk-theme-name', $theme_name);     # uncoverable statement
+	} else {                                                            # uncoverable statement
+		warn "Not able to find theme ${theme_name}.\n";             # uncoverable statement
+	}                                                                   # uncoverable statement
+}
+
+
+fun _set_icon_theme( (Str) $icon_theme_name ) {
+	# uncoverable subroutine
+	# uncoverable branch true
+	return unless _can_set_theme;
+
+	my $i = Gtk3::IconTheme->new;                                       # uncoverable statement
+	$i->set_custom_theme($icon_theme_name);                             # uncoverable statement
+	my $n = $i->choose_icon_for_scale(['gtk-open'], 16, 1, 'no-svg');   # uncoverable statement
+	my $expected_path = m,/$icon_theme_name/.*\Qgtk-open.png\E$,;       # uncoverable statement
+	if ( defined $n && $n->get_filename =~ $expected_path ) {           # uncoverable statement
+		my $settings = Gtk3::Settings::get_default;                 # uncoverable statement
+		$settings->set_property('gtk-icon-theme-name',              # uncoverable statement
+			$icon_theme_name);                                  # uncoverable statement
+	} else {                                                            # uncoverable statement
+		warn "Not able to find icon-theme ${icon_theme_name}.\n";   # uncoverable statement
+	}                                                                   # uncoverable statement
+}
+
+fun import {
+	_scrolled_window_viewport_shim;
+	_set_theme('Flat-Plat');
+	_set_icon_theme('Arc');
 	return;
 }
 

--- a/t/Renard/Curie/Helper.t
+++ b/t/Renard/Curie/Helper.t
@@ -1,13 +1,24 @@
 #!/usr/bin/env perl
 
-use Test::Most tests => 1;
+use Test::Most tests => 2;
 
 use lib 't/lib';
 use CurieTestHelper;
 use Renard::Curie::Setup;
 
-use Renard::Curie::Helper;
+# need to import later --- after we initialise the data dirs
+use Renard::Curie::Helper ();
+
 use Function::Parameters;
+
+
+my $temp = Path::Tiny->tempdir;
+# Add to XDG_DATA_DIRS early so that it is available for system data dir lookup.
+$ENV{XDG_DATA_DIRS} .= join(":", "/usr/local/share", "/usr/share", $temp);
+Gtk3::init;
+
+# we can now import
+Renard::Curie::Helper->import;
 
 subtest "Use helper functions" => fun {
 	my $val = Renard::Curie::Helper->gval(int => 512);
@@ -16,4 +27,96 @@ subtest "Use helper functions" => fun {
 	my $enum = Renard::Curie::Helper->genum(
 		'Gtk3::PackType' => 'GTK_PACK_START' );
 	is( $enum, 0 );
+};
+
+subtest "Theming" => fun {
+	plan skip_all => "Do not need to test theming on Windows"
+		unless Renard::Curie::Helper::_can_set_theme();
+
+	my $settings = Gtk3::Settings::get_default;
+	my $default_theme = 'Adwaita';
+
+	subtest "Check that system data dirs are set properly" => fun {
+		my @data_dirs = Glib::get_system_data_dirs();
+		cmp_deeply( \@data_dirs, supersetof("$temp"), 'Has the temprary data directory');
+	};
+
+	subtest "Set theme" => fun {
+		my $theme_property = 'gtk-theme-name';
+
+		subtest "Try non-existent theme" => fun {
+			$settings->set_property($theme_property, $default_theme);
+
+			my $try_theme = 'Does-Not-Exist';
+			Renard::Curie::Helper::_set_theme($try_theme);
+			isnt( $settings->get_property($theme_property),
+				$try_theme, 'Theme has not changed' );
+		};
+
+		subtest "Try existing theme" => fun {
+			$settings->set_property($theme_property, $default_theme);
+
+			my $try_theme = 'My-Custom-Theme';
+			my $theme_dir = $temp->child('themes', $try_theme);
+			$theme_dir->mkpath;
+			$theme_dir->child('index.theme')->spew_utf8(<<"EOF" );
+[Desktop Entry]
+Type=X-GNOME-Metatheme
+Name=${try_theme}
+Comment=A Test theme
+Encoding=UTF-8
+
+[X-GNOME-Metatheme]
+GtkTheme=${try_theme}
+MetacityTheme=${try_theme}
+EOF
+
+			$theme_dir->child(qw(gtk-3.0 gtk.css))->touchpath;
+
+			Renard::Curie::Helper::_set_theme($try_theme);
+			is( $settings->get_property($theme_property),
+				$try_theme, 'Theme has changed' );
+
+		}
+	};
+
+	subtest "Set icon-theme" => fun {
+		my $icon_theme_property = 'gtk-icon-theme-name';
+
+		subtest "Try non-existent icon theme" => fun {
+			$settings->set_property($icon_theme_property, $default_theme);
+
+			my $try_icon_theme = 'Does-Not-Exist';
+			Renard::Curie::Helper::_set_icon_theme($try_icon_theme);
+			isnt( $settings->get_property($icon_theme_property),
+				$try_icon_theme, 'Icon theme has not changed' );
+		};
+
+		subtest "Try existing icon theme" => fun {
+			$settings->set_property($icon_theme_property, $default_theme);
+
+			my $try_theme = 'My-Custom-Icon-Theme';
+
+			my $icon_theme_dir = $temp->child('icons', $try_theme);
+			$icon_theme_dir->mkpath;
+			$icon_theme_dir->child('index.theme')->spew_utf8(<<"EOF" );
+[Icon Theme]
+Name=${try_theme}
+
+#Directory list
+Directories=actions/16
+
+[actions/16]
+Size=16
+Context=Actions
+Type=Fixed
+EOF
+			$icon_theme_dir->child(qw(actions 16 gtk-open.png))->touchpath;
+
+			Renard::Curie::Helper::_set_icon_theme($try_theme);
+			is( $settings->get_property($icon_theme_property),
+				$try_theme, 'Icon theme has changed' );
+
+		}
+	};
 };


### PR DESCRIPTION
This loads the theme '[Flat-Plat](https://github.com/nana-4/Flat-Plat)' and the icon theme '[Arc](https://github.com/horst3180/arc-icon-theme)' if they are
available. These two themes will still need to be installed in order to
be used by the application.

Fixes <https://github.com/project-renard/curie/issues/32>.

![-home-zaki-downloads-10 1 1 104 7428 pdf 1 _454](https://cloud.githubusercontent.com/assets/94489/22000389/70536770-dc04-11e6-859c-8d338760be47.png)
