### PR TITLE
Remove status bar from the App window

### DIFF
--- a/lib/Renard/Curie/App.glade
+++ b/lib/Renard/Curie/App.glade
@@ -10,26 +10,6 @@
         <property name="can_focus">False</property>
         <property name="orientation">vertical</property>
         <child>
-          <object class="GtkStatusbar" id="statusbar">
-            <property name="visible">True</property>
-            <property name="can_focus">False</property>
-            <property name="margin_left">10</property>
-            <property name="margin_right">10</property>
-            <property name="margin_start">10</property>
-            <property name="margin_end">10</property>
-            <property name="margin_top">6</property>
-            <property name="margin_bottom">6</property>
-            <property name="orientation">vertical</property>
-            <property name="spacing">2</property>
-          </object>
-          <packing>
-            <property name="expand">False</property>
-            <property name="fill">True</property>
-            <property name="pack_type">end</property>
-            <property name="position">0</property>
-          </packing>
-        </child>
-        <child>
           <placeholder/>
         </child>
         <child>


### PR DESCRIPTION
This frees up vertical space.

Fixes <https://github.com/project-renard/curie/issues/40>.


Before:
![xming_2017-03-10_23-32-21](https://cloud.githubusercontent.com/assets/94489/23820928/e2e28078-05e9-11e7-9e32-e78f9b1dd4a7.png)

After:
![xming_2017-03-10_23-31-24](https://cloud.githubusercontent.com/assets/94489/23820929/e8ba4486-05e9-11e7-86fe-c7cc242a56cd.png)
