### PR TITLE
Add gnome-icon-theme to homebrew

### DIFF
--- a/homebrew-packages
+++ b/homebrew-packages
@@ -1,3 +1,4 @@
 gtk+3
 clutter-gtk
 gtk-mac-integration
+gnome-icon-theme


### PR DESCRIPTION
This is so that icons are available under homebrew.

See also <https://github.com/project-renard/homebrew-project-renard/commit/2718821affcfd626ec62198467542df98d9e124d>.
