### PR TITLE
Update for latest Function::Parameters

### DIFF
--- a/bin/curie
+++ b/bin/curie
@@ -46,4 +46,4 @@ use lib "$FindBin::Bin/../lib";
 use Renard::Curie::Setup;
 use Renard::Curie::App;
 
-Renard::Curie::App::main;
+Renard::Curie::App->main;

--- a/lib/Renard/Curie/App.pm
+++ b/lib/Renard/Curie/App.pm
@@ -32,7 +32,7 @@ A L<Gtk3::Window> that contains the main window for the application.
 =cut
 has window => ( is => 'lazy' );
 
-method _build_window :ReturnType(InstanceOf['Gtk3::Window']) {
+method _build_window() :ReturnType(InstanceOf['Gtk3::Window']) {
 	my $window = $self->builder->get_object('main-window');
 }
 
@@ -172,7 +172,7 @@ method run() {
 Initialises the application and sets up signals.
 
 =cut
-method BUILD {
+method BUILD(@) {
 	$self->setup_gtk;
 
 	$self->setup_window;

--- a/lib/Renard/Curie/App.pm
+++ b/lib/Renard/Curie/App.pm
@@ -237,8 +237,8 @@ fun _get_version() :ReturnType(Str) {
 Application entry point.
 
 =cut
-fun main() {
-	my $self = __PACKAGE__->new;
+method main() {
+	$self = __PACKAGE__->new unless ref $self;
 	$self->process_arguments;
 	$self->run;
 }

--- a/lib/Renard/Curie/App.pm
+++ b/lib/Renard/Curie/App.pm
@@ -291,12 +291,12 @@ method open_document( (DocumentModel) $doc ) {
 # Callbacks {{{
 =callback on_open_file_dialog_cb
 
-  fun on_open_file_dialog_cb( $event, $self )
+  callback on_open_file_dialog_cb( $event, $self )
 
 Callback that opens a L<Renard::Curie::Component::FileChooser> component.
 
 =cut
-fun on_open_file_dialog_cb( $event, $self ) {
+callback on_open_file_dialog_cb( $event, $self ) {
 	my $file_chooser = Renard::Curie::Component::FileChooser->new( app => $self );
 	my $dialog = $file_chooser->get_open_file_dialog_with_filters;
 
@@ -313,12 +313,12 @@ fun on_open_file_dialog_cb( $event, $self ) {
 
 =callback on_application_quit_cb
 
-  fun on_application_quit_cb( $event, $self )
+  callback on_application_quit_cb( $event, $self )
 
 Callback that stops the L<Gtk3> main loop.
 
 =cut
-fun on_application_quit_cb( $event, $self ) {
+callback on_application_quit_cb( $event, $self ) {
 	Gtk3::main_quit;
 }
 # }}}

--- a/lib/Renard/Curie/Component/AccelMap.pm
+++ b/lib/Renard/Curie/Component/AccelMap.pm
@@ -10,7 +10,7 @@ use Function::Parameters;
 Constructor that sets up the keybindings for the default accelerator map.
 
 =cut
-method BUILD {
+method BUILD(@) {
 	Gtk3::AccelMap::add_entry(
 		'<Curie-Main>/File/Open',
 		Gtk3::Gdk::KEY_O,

--- a/lib/Renard/Curie/Component/FileChooser.pm
+++ b/lib/Renard/Curie/Component/FileChooser.pm
@@ -26,7 +26,7 @@ has pdf_filter => (
 	isa => InstanceOf['Gtk3::FileFilter'],
 );
 
-method _build_all_filter :ReturnType(InstanceOf['Gtk3::FileFilter']) {
+method _build_all_filter() :ReturnType(InstanceOf['Gtk3::FileFilter']) {
 	my $filter = Gtk3::FileFilter->new;
 	$filter->set_name("All files");
 	$filter->add_pattern("*");
@@ -34,7 +34,7 @@ method _build_all_filter :ReturnType(InstanceOf['Gtk3::FileFilter']) {
 	return $filter;
 }
 
-method _build_pdf_filter :ReturnType(InstanceOf['Gtk3::FileFilter']) {
+method _build_pdf_filter() :ReturnType(InstanceOf['Gtk3::FileFilter']) {
 	my $filter = Gtk3::FileFilter->new;
 	$filter->set_name("PDF files");
 	$filter->add_mime_type("application/pdf");

--- a/lib/Renard/Curie/Component/LogWindow.pm
+++ b/lib/Renard/Curie/Component/LogWindow.pm
@@ -38,7 +38,7 @@ has log_messages => (
 Initialises the logging window.
 
 =cut
-method BUILD {
+method BUILD(@) {
 	my $log_textview = $self->builder->get_object('log-text');
 	if( $log_textview->can('set_monospace') ) {
 		$log_textview->set_monospace(TRUE);

--- a/lib/Renard/Curie/Component/LogWindow.pm
+++ b/lib/Renard/Curie/Component/LogWindow.pm
@@ -117,13 +117,13 @@ method _scroll_log_textview_to_end() {
 
 =callback on_clicked_button_clear_cb
 
-  fun on_clicked_button_clear_cb( $event, $self )
+  callback on_clicked_button_clear_cb( $event, $self )
 
 Callback for when the Clear button is clicked. This clears the log message text
 view.
 
 =cut
-fun on_clicked_button_clear_cb( $event, $self ) {
+callback on_clicked_button_clear_cb( $event, $self ) {
 	$self->log_messages([]);
 	my $buffer = $self->builder->get_object('log-text')->get_buffer;
 	$buffer->set_text("", 0);

--- a/lib/Renard/Curie/Component/MenuBar.pm
+++ b/lib/Renard/Curie/Component/MenuBar.pm
@@ -49,7 +49,7 @@ classmethod FOREIGNBUILDARGS(@) {
 Initialises the menu bar signals.
 
 =cut
-method BUILD {
+method BUILD(@) {
 	# Accelerator group
 	$self->app->window->add_accel_group(
 		$self->builder->get_object('menu-accel-group')
@@ -121,11 +121,11 @@ method BUILD {
 	);
 }
 
-method _build_recent_manager :ReturnType(InstanceOf['Gtk3::RecentManager']) {
+method _build_recent_manager() :ReturnType(InstanceOf['Gtk3::RecentManager']) {
 	Gtk3::RecentManager::get_default;
 }
 
-method _build_recent_chooser :ReturnType(InstanceOf['Gtk3::RecentChooserMenu']) {
+method _build_recent_chooser() :ReturnType(InstanceOf['Gtk3::RecentChooserMenu']) {
 	my $recent_chooser = Gtk3::RecentChooserMenu->new_for_manager( $self->recent_manager );
 }
 

--- a/lib/Renard/Curie/Component/MenuBar.pm
+++ b/lib/Renard/Curie/Component/MenuBar.pm
@@ -133,34 +133,34 @@ method _build_recent_chooser() :ReturnType(InstanceOf['Gtk3::RecentChooserMenu']
 # Callbacks {{{
 =callback on_menu_file_open_activate_cb
 
-  fun on_menu_file_open_activate_cb($event, $self)
+  callback on_menu_file_open_activate_cb($event, $self)
 
 Callback for the C<< File -> Open >> menu item.
 
 =cut
-fun on_menu_file_open_activate_cb($event, $self) {
+callback on_menu_file_open_activate_cb($event, $self) {
 	Renard::Curie::Helper->callback( $self->app, on_open_file_dialog_cb => $event );
 }
 
 =callback on_menu_file_quit_activate_cb
 
-  fun on_menu_file_quit_activate_cb($event, $self)
+  callback on_menu_file_quit_activate_cb($event, $self)
 
 Callback for the C<< File -> Quit >> menu item.
 
 =cut
-fun on_menu_file_quit_activate_cb($event, $self) {
+callback on_menu_file_quit_activate_cb($event, $self) {
 	Renard::Curie::Helper->callback( $self->app, on_application_quit_cb => $event );
 }
 
 =callback on_menu_file_recentfiles_item_activated_cb
 
-  fun on_menu_file_recentfiles_item_activated_cb( (InstanceOf['Gtk3::RecentChooserMenu']) $recent_chooser, $self )
+  callback on_menu_file_recentfiles_item_activated_cb( (InstanceOf['Gtk3::RecentChooserMenu']) $recent_chooser, $self )
 
 Callback for items under the C<< File -> Recent files >> sub-menu.
 
 =cut
-fun on_menu_file_recentfiles_item_activated_cb( (InstanceOf['Gtk3::RecentChooserMenu']) $recent_chooser, $self ) {
+callback on_menu_file_recentfiles_item_activated_cb( (InstanceOf['Gtk3::RecentChooserMenu']) $recent_chooser, $self ) {
 	my $selected_item = $recent_chooser->get_current_item;
 	my $uri = $selected_item->get_uri;
 	my $file = URI->new( $uri )->file;
@@ -169,14 +169,14 @@ fun on_menu_file_recentfiles_item_activated_cb( (InstanceOf['Gtk3::RecentChooser
 
 =callback on_menu_help_logwin_activate_cb
 
-  fun on_menu_help_logwin_activate_cb($event, $self)
+  callback on_menu_help_logwin_activate_cb($event, $self)
 
 Callback for C<< Help -> Message log >> menu item.
 
 Displays the Message log window.
 
 =cut
-fun on_menu_help_logwin_activate_cb($event, $self) {
+callback on_menu_help_logwin_activate_cb($event, $self) {
 	$self->app->log_window->show_log_window;
 }
 
@@ -187,7 +187,7 @@ Callback for the C<< View -> Sidebar >> menu item.
 This toggles whether or not the outline sidebar is visible.
 
 =cut
-fun on_menu_view_sidebar_cb($event_menu_item, $self) {
+callback on_menu_view_sidebar_cb($event_menu_item, $self) {
 	$self->app->outline->reveal( $event_menu_item->get_active );
 }
 
@@ -195,12 +195,12 @@ fun on_menu_view_sidebar_cb($event_menu_item, $self) {
 
 Callback for zoom level menu items under the C<< View -> Zoom >> submenu.
 
-  fun on_menu_view_zoom_item_activate_cb($event, $data)
+  callback on_menu_view_zoom_item_activate_cb($event, $data)
 
 where C<$data> is an C<ArrayRef> that contains C<< [ $self, $zoom_level ] >>.
 
 =cut
-fun on_menu_view_zoom_item_activate_cb($event, $data) {
+callback on_menu_view_zoom_item_activate_cb($event, $data) {
 	my ($self, $zoom_level) = @$data;
 	$self->app->page_document_component->zoom_level( $zoom_level );
 }

--- a/lib/Renard/Curie/Component/Outline.pm
+++ b/lib/Renard/Curie/Component/Outline.pm
@@ -110,13 +110,13 @@ method _trigger_model($new_model) {
 
 =callback on_tree_view_row_activate_cb
 
-  fun on_tree_view_row_activate_cb( $tree_view, $path, $column, $self )
+  callback on_tree_view_row_activate_cb( $tree_view, $path, $column, $self )
 
 Callback that navigates the current document to the position that corresponds
 to a row of the tree that has been clicked.
 
 =cut
-fun on_tree_view_row_activate_cb( $tree_view, $path, $column, $self ) {
+callback on_tree_view_row_activate_cb( $tree_view, $path, $column, $self ) {
 	# NOTE : This needs more error checking.
 
 	my $pd = $self->app->page_document_component;

--- a/lib/Renard/Curie/Component/Outline.pm
+++ b/lib/Renard/Curie/Component/Outline.pm
@@ -50,7 +50,7 @@ This class is a subclass of L<Gtk3::Revealer> which allows the visible state to
 be toggled.
 
 =cut
-method BUILD {
+method BUILD(@) {
 	my $frame = Gtk3::Frame->new('Outline');
 	my $scrolled_window = Gtk3::ScrolledWindow->new;
 	$scrolled_window->set_vexpand(TRUE);

--- a/lib/Renard/Curie/Component/PageDrawingArea.pm
+++ b/lib/Renard/Curie/Component/PageDrawingArea.pm
@@ -135,49 +135,49 @@ method setup_button_events() {
 
 =callback on_clicked_button_first_cb
 
-  fun on_clicked_button_first_cb($button, $self)
+  callback on_clicked_button_first_cb($button, $self)
 
 Callback for when the "First" button is pressed.
 See L</set_current_page_to_first>.
 
 =cut
-fun on_clicked_button_first_cb($button, $self) {
+callback on_clicked_button_first_cb($button, $self) {
 	$self->set_current_page_to_first;
 }
 
 =callback on_clicked_button_last_cb
 
-  fun on_clicked_button_last_cb($button, $self)
+  callback on_clicked_button_last_cb($button, $self)
 
 Callback for when the "Last" button is pressed.
 See L</set_current_page_to_last>.
 
 =cut
-fun on_clicked_button_last_cb($button, $self) {
+callback on_clicked_button_last_cb($button, $self) {
 	$self->set_current_page_to_last;
 }
 
 =callback on_clicked_button_forward_cb
 
-  fun on_clicked_button_forward_cb($button, $self)
+  callback on_clicked_button_forward_cb($button, $self)
 
 Callback for when the "Forward" button is pressed.
 See L</set_current_page_forward>.
 
 =cut
-fun on_clicked_button_forward_cb($button, $self) {
+callback on_clicked_button_forward_cb($button, $self) {
 	$self->set_current_page_forward;
 }
 
 =callback on_clicked_button_back_cb
 
-  fun on_clicked_button_back_cb($button, $self)
+  callback on_clicked_button_back_cb($button, $self)
 
 Callback for when the "Back" button is pressed.
 See L</set_current_page_back>.
 
 =cut
-fun on_clicked_button_back_cb($button, $self) {
+callback on_clicked_button_back_cb($button, $self) {
 	$self->set_current_page_back;
 }
 
@@ -204,7 +204,7 @@ Sets up the L</drawing_area> so that it draws the current page.
 method setup_drawing_area() {
 	my $drawing_area = Gtk3::DrawingArea->new();
 	$self->drawing_area( $drawing_area );
-	$drawing_area->signal_connect( draw => fun (
+	$drawing_area->signal_connect( draw => callback(
 			(InstanceOf['Gtk3::DrawingArea']) $widget,
 			(InstanceOf['Cairo::Context']) $cr) {
 		my $rp = $self->document->get_rendered_page(
@@ -254,13 +254,13 @@ method setup_keybindings() {
 
 =callback on_key_press_event_cb
 
-  fun on_key_press_event_cb($window, $event, $self)
+  callback on_key_press_event_cb($window, $event, $self)
 
 Callback that responds to specific key events and dispatches to the appropriate
 handlers.
 
 =cut
-fun on_key_press_event_cb($window, $event, $self) {
+callback on_key_press_event_cb($window, $event, $self) {
 	if($event->keyval == Gtk3::Gdk::KEY_Page_Down){
 		$self->set_current_page_forward;
 	} elsif($event->keyval == Gtk3::Gdk::KEY_Page_Up){
@@ -369,12 +369,12 @@ method _trigger_zoom_level($new_zoom_level) {
 
 =callback on_activate_page_number_entry_cb
 
-  fun on_activate_page_number_entry_cb( $entry, $self )
+  callback on_activate_page_number_entry_cb( $entry, $self )
 
 Callback that is called when text has been entered into the page number entry.
 
 =cut
-fun on_activate_page_number_entry_cb( $entry, $self ) {
+callback on_activate_page_number_entry_cb( $entry, $self ) {
 	my $text = $entry->get_text;
 	if ($text =~ /^[0-9]+$/ and $text <= $self->document->last_page_number
 			and $text >= $self->document->first_page_number) {

--- a/lib/Renard/Curie/Component/PageDrawingArea.pm
+++ b/lib/Renard/Curie/Component/PageDrawingArea.pm
@@ -96,7 +96,7 @@ classmethod FOREIGNBUILDARGS(@) {
 Initialises the component's contained widgets and signals.
 
 =cut
-method BUILD {
+method BUILD(@) {
 	# so that the widget can take input
 	$self->set_can_focus( TRUE );
 
@@ -351,7 +351,7 @@ the component to retrieve the new page and redraw.
 =end comment
 
 =cut
-method _trigger_current_page_number {
+method _trigger_current_page_number(@) {
 	$self->refresh_drawing_area;
 }
 
@@ -363,7 +363,7 @@ Called whenever the L</zoom_level> is changed. This tells the component to
 redraw the current page at the new zoom level.
 
 =cut
-method _trigger_zoom_level {
+method _trigger_zoom_level() {
 	$self->refresh_drawing_area;
 }
 

--- a/lib/Renard/Curie/Component/PageDrawingArea.pm
+++ b/lib/Renard/Curie/Component/PageDrawingArea.pm
@@ -351,7 +351,7 @@ the component to retrieve the new page and redraw.
 =end comment
 
 =cut
-method _trigger_current_page_number(@) {
+method _trigger_current_page_number($new_page_number) {
 	$self->refresh_drawing_area;
 }
 
@@ -363,7 +363,7 @@ Called whenever the L</zoom_level> is changed. This tells the component to
 redraw the current page at the new zoom level.
 
 =cut
-method _trigger_zoom_level() {
+method _trigger_zoom_level($new_zoom_level) {
 	$self->refresh_drawing_area;
 }
 

--- a/lib/Renard/Curie/Component/Role/FromBuilder.pm
+++ b/lib/Renard/Curie/Component/Role/FromBuilder.pm
@@ -25,11 +25,11 @@ has builder => (
 	isa => InstanceOf['Gtk3::Builder'],
 );
 
-method _build_builder :ReturnType(InstanceOf['Gtk3::Builder']) {
+method _build_builder() :ReturnType(InstanceOf['Gtk3::Builder']) {
 	return Gtk3::Builder->new;
 }
 
-before BUILD => method {
+before BUILD => method(@) {
 	$self->builder->add_from_file( $self->ui_file );
 	$self->builder->connect_signals;
 };

--- a/lib/Renard/Curie/Component/Role/UIFileFromPackageName.pm
+++ b/lib/Renard/Curie/Component/Role/UIFileFromPackageName.pm
@@ -20,15 +20,17 @@ contents of C<ui_file> will be C<lib/Foo/Bar.glade>.
 See the C<ui_file> attribute in L<Renard::Curie::Component::Role::FromBuilder>.
 
 =cut
-has ui_file => ( is => 'ro',
+has ui_file => (
+	is => 'ro',
 	isa => File,
 	coerce => 1,
-	default => method {
+	default => method() {
 		my $module_name = ref $self;
 		my $package_last_component = (split(/::/, $module_name))[-1];
 		my $module_file = find_installed($module_name);
 		File::Spec->catfile(dirname($module_file), "@{[ $package_last_component ]}.glade")
-	} );
+	}
+);
 
 1;
 

--- a/lib/Renard/Curie/Helper.pm
+++ b/lib/Renard/Curie/Helper.pm
@@ -31,7 +31,7 @@ fun _scrolled_window_viewport_shim() {
 		# - <https://developer.gnome.org/gtk3/3.8/GtkScrolledWindow.html>
 		Class::Method::Modifiers::install_modifier
 			"Gtk3::ScrolledWindow",
-			around => add => fun {
+			around => add => fun(@) {
 				# uncoverable subroutine
 				my $orig = shift;             # uncoverable statement
 				my $self = shift;             # uncoverable statement
@@ -40,7 +40,7 @@ fun _scrolled_window_viewport_shim() {
 	}
 }
 
-fun _can_set_theme {
+fun _can_set_theme() {
 	# uncoverable branch true
 	return $^O ne 'MSWin32' && Gtk3::CHECK_VERSION('3', '20', '1');
 }
@@ -79,7 +79,7 @@ fun _set_icon_theme( (Str) $icon_theme_name ) {
 	}                                                                   # uncoverable statement
 }
 
-fun import {
+sub import {
 	_scrolled_window_viewport_shim;
 	_set_theme('Flat-Plat');
 	_set_icon_theme('Arc');

--- a/lib/Renard/Curie/Model/Document/CairoImageSurface.pm
+++ b/lib/Renard/Curie/Model/Document/CairoImageSurface.pm
@@ -20,7 +20,7 @@ has image_surfaces => (
 	required => 1
 );
 
-method _build_last_page_number :ReturnType(PageNumber) {
+method _build_last_page_number() :ReturnType(PageNumber) {
 	return scalar @{ $self->image_surfaces };
 }
 

--- a/lib/Renard/Curie/Model/Document/CairoImageSurface.pm
+++ b/lib/Renard/Curie/Model/Document/CairoImageSurface.pm
@@ -33,7 +33,7 @@ Returns a new L<Renard::Curie::Model::Page::CairoImageSurface> object.
 See L<Renard::Curie::Model::Document::Role::Renderable/get_rendered_page> for more details.
 
 =cut
-method get_rendered_page( (PageNumber) :$page_number ) {
+method get_rendered_page( (PageNumber) :$page_number, @) {
 	my $index = $page_number - 1;
 
 	return Renard::Curie::Model::Page::CairoImageSurface->new(

--- a/lib/Renard/Curie/Model/Document/PDF.pm
+++ b/lib/Renard/Curie/Model/Document/PDF.pm
@@ -21,7 +21,7 @@ C<mutool>.
 =end comment
 
 =cut
-method _build_last_page_number :ReturnType(PageNumber) {
+method _build_last_page_number() :ReturnType(PageNumber) {
 	my $info = Renard::Curie::Data::PDF::get_mutool_page_info_xml(
 		$self->filename
 	);
@@ -48,7 +48,7 @@ method get_rendered_page( (PageNumber) :$page_number, (ZoomLevel) :$zoom_level =
 	);
 }
 
-method _build_outline {
+method _build_outline() {
 	my $outline_data = Renard::Curie::Data::PDF::get_mutool_outline_simple(
 		$self->filename
 	);

--- a/lib/Renard/Curie/Model/Outline.pm
+++ b/lib/Renard/Curie/Model/Outline.pm
@@ -101,7 +101,7 @@ has tree_store => (
 );
 
 
-method _build_tree_store {
+method _build_tree_store() {
 	# load Gtk3 dynamically if used outside Gtk3 context
 	require Gtk3;
 	Gtk3->import(qw(-init));

--- a/lib/Renard/Curie/Model/Page/RenderedFromPNG.pm
+++ b/lib/Renard/Curie/Model/Page/RenderedFromPNG.pm
@@ -22,7 +22,7 @@ has cairo_image_surface => (
 	is => 'lazy', # _build_cairo_image_surface
 );
 
-method _build_cairo_image_surface :ReturnType(InstanceOf['Cairo::ImageSurface']) {
+method _build_cairo_image_surface() :ReturnType(InstanceOf['Cairo::ImageSurface']) {
 	# read the PNG data in-memory
 	my $img = Cairo::ImageSurface->create_from_png_stream(
 		fun ((Str) $callback_data, (Int) $length) {

--- a/lib/Renard/Curie/Model/Page/Role/CairoRenderable.pm
+++ b/lib/Renard/Curie/Model/Page/Role/CairoRenderable.pm
@@ -32,11 +32,11 @@ has [ qw(width height) ] => (
 	isa => PositiveOrZeroInt,
 );
 
-method _build_width :ReturnType(PositiveOrZeroInt) {
+method _build_width() :ReturnType(PositiveOrZeroInt) {
 	$self->cairo_image_surface->get_width;
 }
 
-method _build_height :ReturnType(PositiveOrZeroInt) {
+method _build_height() :ReturnType(PositiveOrZeroInt) {
 	$self->cairo_image_surface->get_height;
 }
 

--- a/lib/Renard/Curie/Setup.pm
+++ b/lib/Renard/Curie/Setup.pm
@@ -30,6 +30,7 @@ sub import {
 			fun         => { defaults => 'function_lax'   , %type_tiny_fp_check },
 			classmethod => { defaults => 'classmethod_lax', %type_tiny_fp_check },
 			method      => { defaults => 'method_lax'     , %type_tiny_fp_check },
+			callback    => { defaults => 'function_lax'   , %type_tiny_fp_check, check_argument_count => 0 },
 		}
 	);
 	Return::Type->import::into( $target );

--- a/lib/Renard/Curie/Setup.pm
+++ b/lib/Renard/Curie/Setup.pm
@@ -27,9 +27,9 @@ sub import {
 	my %type_tiny_fp_check = ( reify_type => sub { Type::Utils::dwim_type($_[0]) }, );
 	Function::Parameters->import::into( $target,
 		{
-			fun         => { defaults => 'function_strict'   , %type_tiny_fp_check },
-			classmethod => { defaults => 'classmethod_strict', %type_tiny_fp_check },
-			method      => { defaults => 'method_strict'     , %type_tiny_fp_check },
+			fun         => { defaults => 'function_lax'   , %type_tiny_fp_check },
+			classmethod => { defaults => 'classmethod_lax', %type_tiny_fp_check },
+			method      => { defaults => 'method_lax'     , %type_tiny_fp_check },
 		}
 	);
 	Return::Type->import::into( $target );

--- a/t/Renard/Curie/App.t
+++ b/t/Renard/Curie/App.t
@@ -9,7 +9,6 @@ use CurieTestHelper;
 use Renard::Curie::Setup;
 use Renard::Curie::App;
 use File::Temp;
-use Function::Parameters;
 use version 0.77 ();
 
 subtest "Process arguments" => sub {

--- a/t/Renard/Curie/App.t
+++ b/t/Renard/Curie/App.t
@@ -12,8 +12,8 @@ use File::Temp;
 use Function::Parameters;
 use version 0.77 ();
 
-subtest "Process arguments" => fun {
-	subtest "Process arguments for PDF file" => fun {
+subtest "Process arguments" => sub {
+	subtest "Process arguments for PDF file" => sub {
 		my $pdf_ref_path = try {
 			CurieTestHelper->test_data_directory->child(qw(PDF Adobe pdf_reference_1-7.pdf));
 		} catch {
@@ -26,7 +26,7 @@ subtest "Process arguments" => fun {
 		undef $app;
 	};
 
-	subtest "Process no arguments" => fun {
+	subtest "Process no arguments" => sub {
 		my $app = Renard::Curie::App->new;
 		local @ARGV = ();
 		lives_ok {
@@ -35,7 +35,7 @@ subtest "Process arguments" => fun {
 		undef $app;
 	};
 
-	subtest "Process arguments for non-existent file" => fun {
+	subtest "Process arguments for non-existent file" => sub {
 		my $non_existent_filename = File::Temp::tmpnam();
 		local @ARGV = ($non_existent_filename);
 		my $app = Renard::Curie::App->new;
@@ -45,7 +45,7 @@ subtest "Process arguments" => fun {
 		undef $app;
 	};
 
-	subtest "Process --help flag" => fun {
+	subtest "Process --help flag" => sub {
 		my $app = Renard::Curie::App->new;
 		local @ARGV = qw(--help);
 		trap { $app->process_arguments; };
@@ -54,7 +54,7 @@ subtest "Process arguments" => fun {
 		undef $app;
 	};
 
-	subtest "Process --version flag" => fun {
+	subtest "Process --version flag" => sub {
 		my $app = Renard::Curie::App->new;
 		local @ARGV = qw(--version);
 		trap { $app->process_arguments; };
@@ -63,7 +63,7 @@ subtest "Process arguments" => fun {
 		undef $app;
 	};
 
-	subtest "Process --short-version flag" => fun {
+	subtest "Process --short-version flag" => sub {
 		my $app = Renard::Curie::App->new;
 		local @ARGV = qw(--short-version);
 		trap { $app->process_arguments; };
@@ -81,11 +81,11 @@ subtest "Process arguments" => fun {
 	};
 };
 
-subtest "Run app and destroy" => fun {
+subtest "Run app and destroy" => sub {
 	plan tests => 2;
 	my $app = Renard::Curie::App->new;
 
-	Glib::Timeout->add(100, fun {
+	Glib::Timeout->add(100, sub {
 		cmp_ok( Gtk3::main_level, '>', 0, 'Main loop is running');
 		$app->window->destroy;
 	});
@@ -97,7 +97,7 @@ subtest "Run app and destroy" => fun {
 	undef $app;
 };
 
-subtest "Open document twice" => fun {
+subtest "Open document twice" => sub {
 	my $app = Renard::Curie::App->new;
 	my $cairo_doc_a = CurieTestHelper->create_cairo_document;
 	my $cairo_doc_b = CurieTestHelper->create_cairo_document;

--- a/t/Renard/Curie/Component/FileChooser.t
+++ b/t/Renard/Curie/Component/FileChooser.t
@@ -12,7 +12,7 @@ use Renard::Curie::Component::FileChooser;
 use Test::MockModule;
 use Function::Parameters;
 
-subtest 'Check that the open file dialog with filters is created' => fun {
+subtest 'Check that the open file dialog with filters is created' => sub {
 	my $app = Renard::Curie::App->new;
 	my $file_chooser = Renard::Curie::Component::FileChooser->new( app => $app );
 
@@ -27,7 +27,7 @@ subtest 'Check that the open file dialog with filters is created' => fun {
 		'Has expected filters' );
 };
 
-subtest "Menu: File -> Open" => fun {
+subtest "Menu: File -> Open" => sub {
 	my $pdf_ref_path = try {
 		CurieTestHelper->test_data_directory->child(qw(PDF Adobe pdf_reference_1-7.pdf));
 	} catch {
@@ -36,10 +36,10 @@ subtest "Menu: File -> Open" => fun {
 
 	my $fc = Test::MockModule->new('Gtk3::FileChooserDialog', no_auto => 1);
 	my ($got_file, $destroyed) = (0, 0);
-	$fc->mock( get_filename => fun { $got_file = 1; "$pdf_ref_path" } );
-	$fc->mock( destroy => fun { $destroyed = 1 } );
+	$fc->mock( get_filename => sub { $got_file = 1; "$pdf_ref_path" } );
+	$fc->mock( destroy => sub { $destroyed = 1 } );
 
-	subtest "Accept dialog" => fun {
+	subtest "Accept dialog" => sub {
 		($got_file, $destroyed) = (0, 0);
 		$fc->mock( run => 'accept' );
 
@@ -51,7 +51,7 @@ subtest "Menu: File -> Open" => fun {
 		ok( $destroyed, "Callback destroyed the dialog");
 	};
 
-	subtest "Cancel dialog" => fun {
+	subtest "Cancel dialog" => sub {
 		($got_file, $destroyed) = (0, 0);
 		$fc->mock( run => 'cancel' );
 

--- a/t/Renard/Curie/Component/FileChooser.t
+++ b/t/Renard/Curie/Component/FileChooser.t
@@ -10,7 +10,6 @@ use Renard::Curie::Helper;
 use Renard::Curie::App;
 use Renard::Curie::Component::FileChooser;
 use Test::MockModule;
-use Function::Parameters;
 
 subtest 'Check that the open file dialog with filters is created' => sub {
 	my $app = Renard::Curie::App->new;

--- a/t/Renard/Curie/Component/KeyBindings.t
+++ b/t/Renard/Curie/Component/KeyBindings.t
@@ -8,7 +8,6 @@ use Renard::Curie::App;
 use Renard::Curie::Model::Document::PDF;
 use CurieTestHelper;
 use Renard::Curie::Types qw(Int InstanceOf);
-use Function::Parameters;
 
 my $cairo_doc = CurieTestHelper->create_cairo_document;
 

--- a/t/Renard/Curie/Component/KeyBindings.t
+++ b/t/Renard/Curie/Component/KeyBindings.t
@@ -18,7 +18,7 @@ fun Key_Event( (InstanceOf['Renard::Curie::App']) $app, (Int) $key) {
 	$app->page_document_component->signal_emit( key_press_event => $event );
 }
 
-subtest 'Check that Page Down moves forward a page and Page Up moves back a page' => fun {
+subtest 'Check that Page Down moves forward a page and Page Up moves back a page' => sub {
 	my ( $app, $page_comp ) = CurieTestHelper->create_app_with_document($cairo_doc);
 
 	is($page_comp->current_page_number, 1, 'Start on page 1' );
@@ -30,11 +30,11 @@ subtest 'Check that Page Down moves forward a page and Page Up moves back a page
 	is($page_comp->current_page_number, 1, 'On page 1 after hitting Page Up' );
 };
 
-subtest 'Check that up arrow scrolls up and down arrow scrolls down' => CurieTestHelper->run_app_with_document($cairo_doc, fun {
+subtest 'Check that up arrow scrolls up and down arrow scrolls down' => CurieTestHelper->run_app_with_document($cairo_doc, sub {
 	plan tests => 2;
 	my ( $app, $page_comp ) = @_;
 
-	Glib::Timeout->add(200, fun {
+	Glib::Timeout->add(200, sub {
 		my $vadj = $page_comp->scrolled_window->get_vadjustment;
 		my $current_value = $vadj->get_value;
 		Key_Event($app, Gtk3::Gdk::KEY_Down);
@@ -50,11 +50,11 @@ subtest 'Check that up arrow scrolls up and down arrow scrolls down' => CurieTes
 	});
 });
 
-subtest 'Check that right arrow scrolls right and left arrow scrolls left' => CurieTestHelper->run_app_with_document($cairo_doc, fun {
+subtest 'Check that right arrow scrolls right and left arrow scrolls left' => CurieTestHelper->run_app_with_document($cairo_doc, sub {
 	plan tests => 2;
 	my ( $app, $page_comp ) = @_;
 
-	Glib::Timeout->add(200, fun {
+	Glib::Timeout->add(200, sub {
 		my $hadj = $page_comp->scrolled_window->get_hadjustment;
 		my $current_value = $hadj->get_value;
 		Key_Event($app, Gtk3::Gdk::KEY_Right);

--- a/t/Renard/Curie/Component/LogWindow.t
+++ b/t/Renard/Curie/Component/LogWindow.t
@@ -6,7 +6,6 @@ use lib 't/lib';
 use CurieTestHelper;
 
 use Renard::Curie::Setup;
-use Function::Parameters;
 use Glib 'TRUE', 'FALSE';
 use Renard::Curie::App;
 

--- a/t/Renard/Curie/Component/LogWindow.t
+++ b/t/Renard/Curie/Component/LogWindow.t
@@ -12,7 +12,7 @@ use Renard::Curie::App;
 
 use Log::Any qw($log);
 
-subtest "Check log buffer" => fun {
+subtest "Check log buffer" => sub {
 	plan tests => 3;
 	my $app = Renard::Curie::App->new;
 

--- a/t/Renard/Curie/Component/MenuBar.t
+++ b/t/Renard/Curie/Component/MenuBar.t
@@ -14,7 +14,7 @@ use Test::MockModule;
 use Test::MockObject;
 use Function::Parameters;
 
-subtest 'Check that the menu item File -> Open exists' => fun {
+subtest 'Check that the menu item File -> Open exists' => sub {
 	require Renard::Curie::App;
 	my $app = Renard::Curie::App->new;
 
@@ -32,7 +32,7 @@ subtest 'Check that the menu item File -> Open exists' => fun {
 		'File -> Open menu item exists' );
 };
 
-subtest "Menu: File -> Open" => fun {
+subtest "Menu: File -> Open" => sub {
 	my $pdf_ref_path = try {
 		CurieTestHelper->test_data_directory->child(qw(PDF Adobe pdf_reference_1-7.pdf));
 	} catch {
@@ -41,10 +41,10 @@ subtest "Menu: File -> Open" => fun {
 
 	my $fc = Test::MockModule->new('Gtk3::FileChooserDialog', no_auto => 1);
 	my ($got_file, $destroyed) = (0, 0);
-	$fc->mock( get_filename => fun { $got_file = 1; "$pdf_ref_path" } );
-	$fc->mock( destroy => fun { $destroyed = 1 } );
+	$fc->mock( get_filename => sub { $got_file = 1; "$pdf_ref_path" } );
+	$fc->mock( destroy => sub { $destroyed = 1 } );
 
-	subtest "Accept dialog" => fun {
+	subtest "Accept dialog" => sub {
 		($got_file, $destroyed) = (0, 0);
 		$fc->mock( run => 'accept' );
 
@@ -56,7 +56,7 @@ subtest "Menu: File -> Open" => fun {
 		ok( $destroyed, "Callback destroyed the dialog");
 	};
 
-	subtest "Cancel dialog" => fun {
+	subtest "Cancel dialog" => sub {
 		($got_file, $destroyed) = (0, 0);
 		$fc->mock( run => 'cancel' );
 
@@ -68,11 +68,11 @@ subtest "Menu: File -> Open" => fun {
 	};
 };
 
-subtest "Menu: File -> Quit" => fun {
+subtest "Menu: File -> Quit" => sub {
 	plan tests => 2;
 	my $app = Renard::Curie::App->new;
 
-	Glib::Timeout->add(100, fun {
+	Glib::Timeout->add(100, sub {
 		cmp_ok( Gtk3::main_level, '>', 0, 'Main loop is running');
 		$app->menu_bar->builder
 			->get_object('menu-item-file-quit')
@@ -84,7 +84,7 @@ subtest "Menu: File -> Quit" => fun {
 	is( Gtk3::main_level, 0, 'Main loop is no longer running');
 };
 
-subtest "Menu: File -> Recent files" => fun {
+subtest "Menu: File -> Recent files" => sub {
 	my $pdf_ref_path = try {
 		CurieTestHelper->test_data_directory->child(qw(PDF Adobe pdf_reference_1-7.pdf));
 	} catch {
@@ -95,7 +95,7 @@ subtest "Menu: File -> Recent files" => fun {
 	my $pdf_ref_uri = URI::file->new_abs( $pdf_ref_path );
 
 	my $pdf_ref_menu_item = Test::MockObject->new;
-	$pdf_ref_menu_item->mock( get_uri => fun { $pdf_ref_uri } );
+	$pdf_ref_menu_item->mock( get_uri => sub { $pdf_ref_uri } );
 
 	my $rc_mock = Test::MockModule->new('Gtk3::RecentChooser', no_auto => 1);
 	$rc_mock->mock( get_current_item => $pdf_ref_menu_item );
@@ -109,7 +109,7 @@ subtest "Menu: File -> Recent files" => fun {
 	is path($app->page_document_component->document->filename), $pdf_ref_path, 'File opened from Recent files';
 };
 
-subtest "Menu: View -> Zoom" => fun {
+subtest "Menu: View -> Zoom" => sub {
 	my $pdf_ref_path = try {
 		CurieTestHelper->test_data_directory->child(qw(PDF Adobe pdf_reference_1-7.pdf));
 	} catch {
@@ -153,7 +153,7 @@ subtest "Menu: View -> Zoom" => fun {
 	};
 };
 
-subtest "Menu: View -> Sidebar" => fun {
+subtest "Menu: View -> Sidebar" => sub {
 	plan tests => 1;
 	my $app = Renard::Curie::App->new;
 
@@ -168,7 +168,7 @@ subtest "Menu: View -> Sidebar" => fun {
 		'outline reveal state has been toggled' );
 };
 
-subtest "Menu: Help -> Message log" => fun {
+subtest "Menu: Help -> Message log" => sub {
 	plan tests => 2;
 	my $app = Renard::Curie::App->new;
 

--- a/t/Renard/Curie/Component/MenuBar.t
+++ b/t/Renard/Curie/Component/MenuBar.t
@@ -12,7 +12,6 @@ use URI::file;
 use List::AllUtils qw(first);
 use Test::MockModule;
 use Test::MockObject;
-use Function::Parameters;
 
 subtest 'Check that the menu item File -> Open exists' => sub {
 	require Renard::Curie::App;

--- a/t/Renard/Curie/Component/Outline.t
+++ b/t/Renard/Curie/Component/Outline.t
@@ -17,7 +17,7 @@ my $pdf_ref_path = try {
 
 plan tests => 2;
 
-subtest 'Check that the outline model is set for the current document' => fun {
+subtest 'Check that the outline model is set for the current document' => sub {
 	my $app = Renard::Curie::App->new;
 	$app->open_pdf_document( $pdf_ref_path );
 	my $doc = $app->page_document_component->document;
@@ -27,7 +27,7 @@ subtest 'Check that the outline model is set for the current document' => fun {
 		"The outline component's model is set to the document's outline model");
 };
 
-subtest 'Check that clicking an outline item sets the page number' => fun {
+subtest 'Check that clicking an outline item sets the page number' => sub {
 	plan tests => 3;
 
 	my $app = Renard::Curie::App->new;

--- a/t/Renard/Curie/Component/Outline.t
+++ b/t/Renard/Curie/Component/Outline.t
@@ -7,7 +7,6 @@ use CurieTestHelper;
 
 use Renard::Curie::Setup;
 use Renard::Curie::App;
-use Function::Parameters;
 
 my $pdf_ref_path = try {
 	CurieTestHelper->test_data_directory->child(qw(PDF Adobe pdf_reference_1-7.pdf));

--- a/t/Renard/Curie/Component/PageDrawingArea.t
+++ b/t/Renard/Curie/Component/PageDrawingArea.t
@@ -10,7 +10,7 @@ use Function::Parameters;
 
 my $cairo_doc = CurieTestHelper->create_cairo_document;
 
-subtest 'Check that moving forward and backward changes the page number' => fun {
+subtest 'Check that moving forward and backward changes the page number' => sub {
 	my ($app, $page_comp) = CurieTestHelper->create_app_with_document($cairo_doc);
 
 	my $forward_button = $page_comp->builder->get_object('button-forward');
@@ -28,7 +28,7 @@ subtest 'Check that moving forward and backward changes the page number' => fun 
 	is($page_comp->current_page_number, 2, 'On page 2 after hitting back' );
 };
 
-subtest 'Check that the first and last buttons work' => fun {
+subtest 'Check that the first and last buttons work' => sub {
 	my ($app, $page_comp) = CurieTestHelper->create_app_with_document($cairo_doc);
 
 	my $first_button = $page_comp->builder->get_object('button-first');
@@ -36,7 +36,7 @@ subtest 'Check that the first and last buttons work' => fun {
 
 	is($page_comp->current_page_number, 1, 'Start on page 1' );
 
-	subtest "Check first button" => fun {
+	subtest "Check first button" => sub {
 		$page_comp->current_page_number(3);
 		is $page_comp->current_page_number, 3, "Setting page to 3";
 
@@ -44,7 +44,7 @@ subtest 'Check that the first and last buttons work' => fun {
 		is($page_comp->current_page_number, 1, 'On page 1 after hitting first' );
 	};
 
-	subtest "Check last button" => fun {
+	subtest "Check last button" => sub {
 		$page_comp->current_page_number(2);
 		is $page_comp->current_page_number, 2, "Setting page to 2";
 
@@ -53,7 +53,7 @@ subtest 'Check that the first and last buttons work' => fun {
 	};
 };
 
-subtest 'Check that the current button sensitivity is set on the first and last page' => fun {
+subtest 'Check that the current button sensitivity is set on the first and last page' => sub {
 	my ($app, $page_comp) = CurieTestHelper->create_app_with_document($cairo_doc);
 
 	my $first_button = $page_comp->builder->get_object('button-first');
@@ -82,7 +82,7 @@ subtest 'Check that the current button sensitivity is set on the first and last 
 	ok ! $forward_button->is_sensitive, 'button-forward is disabled on last page';
 };
 
-subtest 'Check the number of pages label' => fun {
+subtest 'Check the number of pages label' => sub {
 	my ($app, $page_comp) = CurieTestHelper->create_app_with_document($cairo_doc);
 
 	my $number_of_pages_label;
@@ -94,7 +94,7 @@ subtest 'Check the number of pages label' => fun {
 	is( $number_of_pages_label->get_text() , '4', 'Number of pages should be equal to four.' );
 };
 
-subtest 'Check the page entry' => fun {
+subtest 'Check the page entry' => sub {
 	my ($app, $page_comp) = CurieTestHelper->create_app_with_document($cairo_doc);
 
 	my $entry = $page_comp->builder->get_object('page-number-entry');
@@ -111,7 +111,7 @@ subtest 'Check the page entry' => fun {
 	is $page_comp->current_page_number, 3, "Page number was changed";
 };
 
-subtest 'Page number bound checking' => fun {
+subtest 'Page number bound checking' => sub {
 	my ($app, $page_comp) = CurieTestHelper->create_app_with_document($cairo_doc);
 
 	$page_comp->set_current_page_to_first;

--- a/t/Renard/Curie/Component/PageDrawingArea.t
+++ b/t/Renard/Curie/Component/PageDrawingArea.t
@@ -6,7 +6,6 @@ use lib 't/lib';
 use CurieTestHelper;
 
 use Renard::Curie::Setup;
-use Function::Parameters;
 
 my $cairo_doc = CurieTestHelper->create_cairo_document;
 

--- a/t/Renard/Curie/Data/PDF.t
+++ b/t/Renard/Curie/Data/PDF.t
@@ -8,7 +8,6 @@ use CurieTestHelper;
 use Renard::Curie::Setup;
 use Renard::Curie::Data::PDF;
 use Data::DPath qw(dpathi);
-use Function::Parameters;
 
 my $pdf_ref_path = try {
 	CurieTestHelper->test_data_directory->child(qw(PDF Adobe pdf_reference_1-7.pdf));

--- a/t/Renard/Curie/Data/PDF.t
+++ b/t/Renard/Curie/Data/PDF.t
@@ -18,12 +18,12 @@ my $pdf_ref_path = try {
 
 plan tests => 4;
 
-subtest 'PDF page to PNG' => fun {
+subtest 'PDF page to PNG' => sub {
 	my $png_data = Renard::Curie::Data::PDF::get_mutool_pdf_page_as_png( $pdf_ref_path, 1, 1.0 );
 	like $png_data, qr/^\x{89}PNG/, 'data has PNG stream magic number';
 };
 
-subtest 'Get bounds of PDF page' => fun {
+subtest 'Get bounds of PDF page' => sub {
 	my $bounds = Renard::Curie::Data::PDF::get_mutool_page_info_xml( $pdf_ref_path );
 
 	my $first_page = $bounds->{page}[0];
@@ -31,7 +31,7 @@ subtest 'Get bounds of PDF page' => fun {
 	is_deeply( $first_page->{CropBox}, { b => 0, t => 666, l => 0, r => 531 }, 'has the expected CropBox' );
 };
 
-subtest 'Get characters for preface' => fun {
+subtest 'Get characters for preface' => sub {
 	my $preface_page = 23;
 
 	my $stext = Renard::Curie::Data::PDF::get_mutool_text_stext_xml( $pdf_ref_path, $preface_page );
@@ -48,7 +48,7 @@ subtest 'Get characters for preface' => fun {
 		'Page text contains expected substring' );
 };
 
-subtest 'Get outline of PDF document' => fun {
+subtest 'Get outline of PDF document' => sub {
 	my $outline_data = Renard::Curie::Data::PDF::get_mutool_outline_simple( $pdf_ref_path );
 
 	cmp_deeply $outline_data,

--- a/t/Renard/Curie/Helper.t
+++ b/t/Renard/Curie/Helper.t
@@ -9,9 +9,6 @@ use Renard::Curie::Setup;
 # need to import later --- after we initialise the data dirs
 use Renard::Curie::Helper ();
 
-use Function::Parameters;
-
-
 my $temp = Path::Tiny->tempdir;
 # Add to XDG_DATA_DIRS early so that it is available for system data dir lookup.
 $ENV{XDG_DATA_DIRS} .= join(":", "/usr/local/share", "/usr/share", $temp);

--- a/t/Renard/Curie/Helper.t
+++ b/t/Renard/Curie/Helper.t
@@ -20,7 +20,7 @@ Gtk3::init;
 # we can now import
 Renard::Curie::Helper->import;
 
-subtest "Use helper functions" => fun {
+subtest "Use helper functions" => sub {
 	my $val = Renard::Curie::Helper->gval(int => 512);
 	isa_ok( $val, 'Glib::Object::Introspection::GValueWrapper' );
 
@@ -29,22 +29,22 @@ subtest "Use helper functions" => fun {
 	is( $enum, 0 );
 };
 
-subtest "Theming" => fun {
+subtest "Theming" => sub {
 	plan skip_all => "Do not need to test theming on Windows"
 		unless Renard::Curie::Helper::_can_set_theme();
 
 	my $settings = Gtk3::Settings::get_default;
 	my $default_theme = 'Adwaita';
 
-	subtest "Check that system data dirs are set properly" => fun {
+	subtest "Check that system data dirs are set properly" => sub {
 		my @data_dirs = Glib::get_system_data_dirs();
 		cmp_deeply( \@data_dirs, supersetof("$temp"), 'Has the temprary data directory');
 	};
 
-	subtest "Set theme" => fun {
+	subtest "Set theme" => sub {
 		my $theme_property = 'gtk-theme-name';
 
-		subtest "Try non-existent theme" => fun {
+		subtest "Try non-existent theme" => sub {
 			$settings->set_property($theme_property, $default_theme);
 
 			my $try_theme = 'Does-Not-Exist';
@@ -53,7 +53,7 @@ subtest "Theming" => fun {
 				$try_theme, 'Theme has not changed' );
 		};
 
-		subtest "Try existing theme" => fun {
+		subtest "Try existing theme" => sub {
 			$settings->set_property($theme_property, $default_theme);
 
 			my $try_theme = 'My-Custom-Theme';
@@ -80,10 +80,10 @@ EOF
 		}
 	};
 
-	subtest "Set icon-theme" => fun {
+	subtest "Set icon-theme" => sub {
 		my $icon_theme_property = 'gtk-icon-theme-name';
 
-		subtest "Try non-existent icon theme" => fun {
+		subtest "Try non-existent icon theme" => sub {
 			$settings->set_property($icon_theme_property, $default_theme);
 
 			my $try_icon_theme = 'Does-Not-Exist';
@@ -92,7 +92,7 @@ EOF
 				$try_icon_theme, 'Icon theme has not changed' );
 		};
 
-		subtest "Try existing icon theme" => fun {
+		subtest "Try existing icon theme" => sub {
 			$settings->set_property($icon_theme_property, $default_theme);
 
 			my $try_theme = 'My-Custom-Icon-Theme';

--- a/t/Renard/Curie/Model/Document/CairoImageSurface.t
+++ b/t/Renard/Curie/Model/Document/CairoImageSurface.t
@@ -7,7 +7,6 @@ use CurieTestHelper;
 
 use Renard::Curie::Setup;
 use Renard::Curie::Model::Document::CairoImageSurface;
-use Function::Parameters;
 
 subtest 'Cairo document model' => sub {
 	my $cairo_doc = CurieTestHelper->create_cairo_document;

--- a/t/Renard/Curie/Model/Document/CairoImageSurface.t
+++ b/t/Renard/Curie/Model/Document/CairoImageSurface.t
@@ -9,7 +9,7 @@ use Renard::Curie::Setup;
 use Renard::Curie::Model::Document::CairoImageSurface;
 use Function::Parameters;
 
-subtest 'Cairo document model' => fun {
+subtest 'Cairo document model' => sub {
 	my $cairo_doc = CurieTestHelper->create_cairo_document;
 
 	ok( $cairo_doc, "Cairo document object created successfully" );

--- a/t/Renard/Curie/Model/Document/PDF.t
+++ b/t/Renard/Curie/Model/Document/PDF.t
@@ -7,7 +7,6 @@ use CurieTestHelper;
 
 use Renard::Curie::Setup;
 use Renard::Curie::Model::Document::PDF;
-use Function::Parameters;
 
 my $pdf_ref_path = try {
 	CurieTestHelper->test_data_directory->child(qw(PDF Adobe pdf_reference_1-7.pdf));

--- a/t/Renard/Curie/Model/Document/PDF.t
+++ b/t/Renard/Curie/Model/Document/PDF.t
@@ -17,7 +17,7 @@ my $pdf_ref_path = try {
 
 plan tests => 1;
 
-subtest pdf_ref => fun {
+subtest pdf_ref => sub {
 	my $pdf_doc = Renard::Curie::Model::Document::PDF->new(
 		filename => $pdf_ref_path
 	);

--- a/t/Renard/Curie/Model/Document/Role/Cacheable.t
+++ b/t/Renard/Curie/Model/Document/Role/Cacheable.t
@@ -7,7 +7,6 @@ use CurieTestHelper;
 
 use Renard::Curie::Setup;
 use Renard::Curie::Model::Document::CairoImageSurface;
-use Function::Parameters;
 
 subtest 'Cairo document model' => sub {
 	my $cairo_doc = CurieTestHelper->create_cairo_document;

--- a/t/Renard/Curie/Model/Document/Role/Cacheable.t
+++ b/t/Renard/Curie/Model/Document/Role/Cacheable.t
@@ -9,7 +9,7 @@ use Renard::Curie::Setup;
 use Renard::Curie::Model::Document::CairoImageSurface;
 use Function::Parameters;
 
-subtest 'Cairo document model' => fun {
+subtest 'Cairo document model' => sub {
 	my $cairo_doc = CurieTestHelper->create_cairo_document;
 	Role::Tiny->apply_roles_to_object( $cairo_doc,
 		qw(Renard::Curie::Model::Document::Role::Cacheable) );

--- a/t/Renard/Curie/Model/Outline.t
+++ b/t/Renard/Curie/Model/Outline.t
@@ -42,7 +42,7 @@ fun walk_rows($store, $treeiter, $level, $callback) {
 	}
 }
 
-subtest 'Outline item type-checking' => fun {
+subtest 'Outline item type-checking' => sub {
 	my @valid_outlines = (
 		[
 			{ level => 0, text  => 'Chapter 1', page  => 20, },
@@ -82,7 +82,7 @@ subtest 'Outline item type-checking' => fun {
 	}
 };
 
-subtest 'Check that the tree store matches the items' => fun {
+subtest 'Check that the tree store matches the items' => sub {
 	my $doc = Renard::Curie::Model::Document::PDF
 		->new( filename => $pdf_ref_path );
 	my $outline = $doc->outline;

--- a/t/Renard/Curie/Model/Outline.t
+++ b/t/Renard/Curie/Model/Outline.t
@@ -8,7 +8,6 @@ use CurieTestHelper;
 use Renard::Curie::Setup;
 use Renard::Curie::Model::Outline;
 use Renard::Curie::Model::Document::PDF;
-use Function::Parameters;
 
 my $pdf_ref_path = try {
 	CurieTestHelper->test_data_directory->child(qw(PDF Adobe pdf_reference_1-7.pdf));

--- a/t/Renard/Curie/Model/Page/RenderedFromPNG.t
+++ b/t/Renard/Curie/Model/Page/RenderedFromPNG.t
@@ -9,7 +9,7 @@ use Renard::Curie::Setup;
 use Renard::Curie::Model::Page::RenderedFromPNG;
 use Function::Parameters;
 
-subtest "Process arguments for PDF file" => fun {
+subtest "Process arguments for PDF file" => sub {
 	my $png_path = try {
 		CurieTestHelper->test_data_directory->child(qw(PNG libpng ccwn3p08.png));
 	} catch {

--- a/t/Renard/Curie/Model/Page/RenderedFromPNG.t
+++ b/t/Renard/Curie/Model/Page/RenderedFromPNG.t
@@ -7,7 +7,6 @@ use CurieTestHelper;
 
 use Renard::Curie::Setup;
 use Renard::Curie::Model::Page::RenderedFromPNG;
-use Function::Parameters;
 
 subtest "Process arguments for PDF file" => sub {
 	my $png_path = try {

--- a/t/lib/CurieTestHelper.pm
+++ b/t/lib/CurieTestHelper.pm
@@ -113,7 +113,7 @@ the document C<$document>.
 =cut
 classmethod run_app_with_document( (DocumentModel) $document, (CodeRef) $callback) :ReturnType(CodeRef) {
 	my ($app, $page_component) = $class->create_app_with_document($document);
-	return fun {
+	return sub {
 		$callback->( $app, $page_component );
 
 		$app->run;

--- a/t/lib/CurieTestHelper.pm
+++ b/t/lib/CurieTestHelper.pm
@@ -1,6 +1,5 @@
 use Renard::Curie::Setup;
 package CurieTestHelper;
-use Function::Parameters;
 use Renard::Curie::Types qw(CodeRef InstanceOf Maybe PositiveInt DocumentModel Dir Tuple);
 
 =func test_data_directory


### PR DESCRIPTION
- Make sure `*_lax` is used for all keywords.
- Change anonymous 0-arity `fun` with no arguments to `sub`.
- Add a `callback` keyword.
- Make sure all the Moo attribute triggers take the new value as an argument.

Fixes <https://github.com/project-renard/curie/issues/190>.