### PR TITLE
Add opened documents to Gtk3::RecentManager

### DIFF
--- a/cpanfile
+++ b/cpanfile
@@ -31,6 +31,7 @@ requires 'Type::Utils';
 requires 'Types::Common::Numeric';
 requires 'Types::Path::Tiny';
 requires 'Types::Standard';
+requires 'Types::URI';
 requires 'URI';
 requires 'URI::file';
 requires 'XML::Simple';

--- a/lib/Renard/Curie/App.pm
+++ b/lib/Renard/Curie/App.pm
@@ -288,6 +288,8 @@ method open_pdf_document( (Path->coercibles) $pdf_filename ) {
 		filename => $pdf_filename,
 	);
 
+	my $rm_added = $self->menu_bar->recent_manager->add_item( $doc->filename_uri );
+
 	# set window title
 	$self->window->set_title( $pdf_filename );
 

--- a/lib/Renard/Curie/Component/MenuBar.pm
+++ b/lib/Renard/Curie/Component/MenuBar.pm
@@ -127,6 +127,9 @@ method _build_recent_manager() :ReturnType(InstanceOf['Gtk3::RecentManager']) {
 
 method _build_recent_chooser() :ReturnType(InstanceOf['Gtk3::RecentChooserMenu']) {
 	my $recent_chooser = Gtk3::RecentChooserMenu->new_for_manager( $self->recent_manager );
+	$recent_chooser->set_sort_type('mru');
+
+	$recent_chooser;
 }
 
 

--- a/lib/Renard/Curie/Model/Document/Role/FromFile.pm
+++ b/lib/Renard/Curie/Model/Document/Role/FromFile.pm
@@ -3,11 +3,11 @@ package Renard::Curie::Model::Document::Role::FromFile;
 # ABSTRACT: Role that provides a filename for a document
 
 use Moo::Role;
-use Renard::Curie::Types qw(File);
+use Renard::Curie::Types qw(File FileUri);
 
 =attr filename
 
-A C<Str> containing the path to a document.
+A C<File> containing the path to a document.
 
 =cut
 has filename => (
@@ -15,5 +15,19 @@ has filename => (
 	isa => File,
 	coerce => 1,
 );
+
+=attr filename_uri
+
+A C<FileUri> containing the path to the document as a URI.
+
+=cut
+has filename_uri => (
+	is => 'lazy', # _build_filename_uri
+	isa => FileUri,
+);
+
+method _build_filename_uri() :ReturnType(FileUri) {
+	FileUri->coerce($self->filename);
+}
 
 1;

--- a/lib/Renard/Curie/Types.pm
+++ b/lib/Renard/Curie/Types.pm
@@ -12,6 +12,7 @@ use Type::Utils -all;
 
 # Listed here so that scan-perl-deps can find them
 use Types::Path::Tiny      ();
+use Types::URI             ();
 use Types::Standard        ();
 use Types::Common::Numeric qw(PositiveInt PositiveOrZeroInt PositiveNum);
 
@@ -21,6 +22,7 @@ Type::Libraries->setup_class(
 	qw(
 		Types::Standard
 		Types::Path::Tiny
+		Types::URI
 		Types::Common::Numeric
 	)
 );


### PR DESCRIPTION
This adds an attribute to get the file: URI for the document and then
uses that URI to update the default Gtk3::RecentManager

Fixes <https://github.com/project-renard/curie/issues/192>.
