### PR TITLE
Refactoring PageDrawingArea into separate views

### DIFF
--- a/dist.ini
+++ b/dist.ini
@@ -25,14 +25,16 @@ Test::PodSpelling.stopwords[ 9] = MuPDF
 Test::PodSpelling.stopwords[10] = revealer
 ; for the function name
 Test::PodSpelling.stopwords[11] = FOREIGNBUILDARGS
-Test::PodSpelling.stopwords[12] = DocumentModel
+Test::PodSpelling.stopwords[12] = BUILDARGS
+Test::PodSpelling.stopwords[13] = DocumentModel
 ; Types
-Test::PodSpelling.stopwords[13] = GtkPackType
-Test::PodSpelling.stopwords[14] = PageNumber
-Test::PodSpelling.stopwords[15] = LaxPageNumber
-Test::PodSpelling.stopwords[16] = ZoomLevel
-Test::PodSpelling.stopwords[17] = RenderableDocumentModel
-Test::PodSpelling.stopwords[18] = RenderablePageModel
+Test::PodSpelling.stopwords[14] = GtkPackType
+Test::PodSpelling.stopwords[15] = PageNumber
+Test::PodSpelling.stopwords[16] = LaxPageNumber
+Test::PodSpelling.stopwords[17] = ZoomLevel
+Test::PodSpelling.stopwords[18] = RenderableDocumentModel
+Test::PodSpelling.stopwords[19] = RenderablePageModel
+Test::PodSpelling.stopwords[20] = SizeRequest
 
 ;=======================================================================
 

--- a/lib/Renard/Curie/Component/MenuBar.glade
+++ b/lib/Renard/Curie/Component/MenuBar.glade
@@ -158,7 +158,7 @@
             <property name="visible">True</property>
             <property name="can_focus">False</property>
             <property name="accel_group">menu-accel-group</property>
-            <!--<child>
+            <child>
               <object class="GtkCheckMenuItem" id="menu-item-view-continuous">
                 <property name="visible">True</property>
                 <property name="can_focus">False</property>
@@ -166,7 +166,7 @@
                 <property name="use_underline">True</property>
               </object>
             </child>
-            <child>
+            <!--<child>
               <object class="GtkSeparatorMenuItem" id="separatormenuitem2">
                 <property name="visible">True</property>
                 <property name="can_focus">False</property>

--- a/lib/Renard/Curie/Component/MenuBar.pm
+++ b/lib/Renard/Curie/Component/MenuBar.pm
@@ -10,6 +10,9 @@ use Function::Parameters;
 use Renard::Curie::Types qw(InstanceOf);
 use Renard::Curie::Helper;
 
+use Renard::Curie::Model::View::ContinuousPage;
+use Renard::Curie::Model::View::SinglePage;
+
 =attr recent_manager
 
 A lazy attribute that holds the default instance of L<Gtk3::RecentManager>.
@@ -73,6 +76,11 @@ method BUILD(@) {
 	# View menu
 	#$self->builder->get_object('menu-item-view-pagemode-singlepage')
 		#->set_active(TRUE);
+	## View -> Continuous
+
+	$self->builder->get_object('menu-item-view-continuous')
+		->signal_connect( toggled =>
+			\&on_menu_view_continuous_cb, $self );
 
 	# Make sure that the menu-item-view-sidebar object matches
 	# the outline's revealer state once the application starts.
@@ -181,6 +189,26 @@ Displays the Message log window.
 =cut
 callback on_menu_help_logwin_activate_cb($event, $self) {
 	$self->app->log_window->show_log_window;
+}
+
+=callback on_menu_view_continuous_cb
+
+TODO
+
+=cut
+callback on_menu_view_continuous_cb( $event_menu_item, $self ) {
+	my $document = $self->app->page_document_component->view->document;
+	my $view;
+	if( $event_menu_item->get_active ) {
+		$view = Renard::Curie::Model::View::ContinuousPage->new(
+			document => $document
+		);
+	} else {
+		$view = Renard::Curie::Model::View::SinglePage->new(
+			document => $document
+		);
+	}
+	$self->app->page_document_component->view( $view );
 }
 
 =callback on_menu_view_sidebar_cb

--- a/lib/Renard/Curie/Component/MenuBar.pm
+++ b/lib/Renard/Curie/Component/MenuBar.pm
@@ -205,7 +205,7 @@ where C<$data> is an C<ArrayRef> that contains C<< [ $self, $zoom_level ] >>.
 =cut
 callback on_menu_view_zoom_item_activate_cb($event, $data) {
 	my ($self, $zoom_level) = @$data;
-	$self->app->page_document_component->zoom_level( $zoom_level );
+	$self->app->page_document_component->view->zoom_level( $zoom_level );
 }
 
 # }}}

--- a/lib/Renard/Curie/Component/MenuBar.pm
+++ b/lib/Renard/Curie/Component/MenuBar.pm
@@ -193,7 +193,9 @@ callback on_menu_help_logwin_activate_cb($event, $self) {
 
 =callback on_menu_view_continuous_cb
 
-TODO
+Callback for C<< View -> Continuous >> menu item.
+
+Toggles the view between a continuous page view and single page view.
 
 =cut
 callback on_menu_view_continuous_cb( $event_menu_item, $self ) {

--- a/lib/Renard/Curie/Component/Outline.pm
+++ b/lib/Renard/Curie/Component/Outline.pm
@@ -124,7 +124,7 @@ callback on_tree_view_row_activate_cb( $tree_view, $path, $column, $self ) {
 	my $iter = $self->model->get_iter( $path );
 	my $page_num = $self->model->get_value($iter, 1);
 
-	PageNumber->check($page_num) and $pd->current_page_number( $page_num );
+	PageNumber->check($page_num) and $pd->view->page_number( $page_num );
 }
 
 =method reveal

--- a/lib/Renard/Curie/Component/PageDrawingArea.pm
+++ b/lib/Renard/Curie/Component/PageDrawingArea.pm
@@ -107,6 +107,8 @@ method BUILD(@) {
 	$self->add(
 		$self->builder->get_object('page-drawing-component')
 	);
+
+	$self->view->signal_emit('view-changed');
 }
 
 =method setup_button_events

--- a/lib/Renard/Curie/Component/PageDrawingArea.pm
+++ b/lib/Renard/Curie/Component/PageDrawingArea.pm
@@ -18,7 +18,7 @@ use Renard::Curie::Model::View::ContinuousPage;
 
 =attr view
 
-TODO
+The view model that is used to render pages.
 
 =cut
 has view => (
@@ -54,6 +54,13 @@ has scrolled_window => (
 
 =cut
 
+=method BUILDARGS
+
+If an object is created with the C<document> argument, a
+L<Renard::Curie::Model::View::SinglePage> view model is created for that
+document.
+
+=cut
 around BUILDARGS => sub {
 	my ( $orig, $class, %args ) = @_;
 

--- a/lib/Renard/Curie/Component/PageDrawingArea.pm
+++ b/lib/Renard/Curie/Component/PageDrawingArea.pm
@@ -20,7 +20,6 @@ has view => (
 	required => 1
 );
 
-method current_page_number() { $self->view->page_number }
 method zoom_level() { $self->view->zoom_level }
 
 =attr drawing_area

--- a/lib/Renard/Curie/Component/PageDrawingArea.pm
+++ b/lib/Renard/Curie/Component/PageDrawingArea.pm
@@ -88,7 +88,13 @@ method BUILD(@) {
 	# so that the widget can take input
 	$self->view->signal_connect( 'view-changed', sub {
 		$self->signal_emit('update-scroll-adjustment');
-		$self->refresh_drawing_area;
+		if( $self->view->can('get_size_request') ) {
+			$self->drawing_area->set_size_request(
+				$self->view->get_size_request
+			);
+		} else {
+			$self->refresh_drawing_area;
+		}
 	} );
 	$self->signal_connect( 'update-scroll-adjustment', sub {
 		if( $self->view->can('update_scroll_adjustment') ) {

--- a/lib/Renard/Curie/Component/PageDrawingArea.pm
+++ b/lib/Renard/Curie/Component/PageDrawingArea.pm
@@ -333,17 +333,7 @@ method on_draw_page_cb( (InstanceOf['Cairo::Context']) $cr ) {
 	# callbacks with $self as the last argument.
 	$self->set_navigation_buttons_sensitivity;
 
-	my $rp = $self->view->rendered_page;
-
-	my $img = $rp->cairo_image_surface;
-
-	$cr->set_source_surface($img, ($self->drawing_area->get_allocated_width -
-		$rp->width) / 2, 0);
-	$cr->paint;
-
-	$self->drawing_area->set_size_request(
-		$rp->width,
-		$rp->height );
+	$self->view->draw_page( $self->drawing_area, $cr );
 
 	$self->builder->get_object('page-number-entry')
 		->set_text($self->view->page_number);

--- a/lib/Renard/Curie/Component/PageDrawingArea.pm
+++ b/lib/Renard/Curie/Component/PageDrawingArea.pm
@@ -119,7 +119,7 @@ See L</set_current_page_to_first>.
 
 =cut
 callback on_clicked_button_first_cb($button, $self) {
-	$self->set_current_page_to_first;
+	$self->view->set_current_page_to_first;
 }
 
 =callback on_clicked_button_last_cb
@@ -131,7 +131,7 @@ See L</set_current_page_to_last>.
 
 =cut
 callback on_clicked_button_last_cb($button, $self) {
-	$self->set_current_page_to_last;
+	$self->view->set_current_page_to_last;
 }
 
 =callback on_clicked_button_forward_cb
@@ -143,7 +143,7 @@ See L</set_current_page_forward>.
 
 =cut
 callback on_clicked_button_forward_cb($button, $self) {
-	$self->set_current_page_forward;
+	$self->view->set_current_page_forward;
 }
 
 =callback on_clicked_button_back_cb
@@ -155,7 +155,7 @@ See L</set_current_page_back>.
 
 =cut
 callback on_clicked_button_back_cb($button, $self) {
-	$self->set_current_page_back;
+	$self->view->set_current_page_back;
 }
 
 =method setup_text_entry_events
@@ -234,9 +234,9 @@ handlers.
 =cut
 callback on_key_press_event_cb($window, $event, $self) {
 	if($event->keyval == Gtk3::Gdk::KEY_Page_Down){
-		$self->set_current_page_forward;
+		$self->view->set_current_page_forward;
 	} elsif($event->keyval == Gtk3::Gdk::KEY_Page_Up){
-		$self->set_current_page_back;
+		$self->view->set_current_page_back;
 	} elsif($event->keyval == Gtk3::Gdk::KEY_Up){
 		decrement_scroll($self->scrolled_window->get_vadjustment);
 	} elsif($event->keyval == Gtk3::Gdk::KEY_Down){
@@ -355,76 +355,6 @@ callback on_activate_page_number_entry_cb( $entry, $self ) {
 	}
 }
 
-=method set_current_page_forward
-
-  method set_current_page_forward()
-
-Increments the current page number if possible.
-
-=cut
-method set_current_page_forward() {
-	if( $self->can_move_to_next_page ) {
-		$self->view->page_number( $self->view->page_number + 1 );
-	}
-}
-
-=method set_current_page_back
-
-  method set_current_page_back()
-
-Decrements the current page number if possible.
-
-=cut
-method set_current_page_back() {
-	if( $self->can_move_to_previous_page ) {
-		$self->view->page_number( $self->view->page_number - 1 );
-	}
-}
-
-=method set_current_page_to_first
-
-  method set_current_page_to_first()
-
-Sets the page number to the first page of the document.
-
-=cut
-method set_current_page_to_first() {
-	$self->view->page_number( $self->view->document->first_page_number );
-}
-
-=method set_current_page_to_last
-
-  method set_current_page_to_last()
-
-Sets the current page to the last page of the document.
-
-=cut
-method set_current_page_to_last() {
-	$self->view->page_number( $self->view->document->last_page_number );
-}
-
-=method can_move_to_previous_page
-
-  method can_move_to_previous_page() :ReturnType(Bool)
-
-Predicate to check if we can decrement the current page number.
-
-=cut
-method can_move_to_previous_page() :ReturnType(Bool) {
-	$self->view->page_number > $self->view->document->first_page_number;
-}
-
-=method can_move_to_next_page
-
-  method can_move_to_next_page() :ReturnType(Bool)
-
-Predicate to check if we can increment the current page number.
-
-=cut
-method can_move_to_next_page() :ReturnType(Bool) {
-	$self->view->page_number < $self->view->document->last_page_number;
-}
-
 =method set_navigation_buttons_sensitivity
 
   set_navigation_buttons_sensitivity()
@@ -434,8 +364,8 @@ start of the document respectively.
 
 =cut
 method set_navigation_buttons_sensitivity() {
-	my $can_move_forward = $self->can_move_to_next_page;
-	my $can_move_back = $self->can_move_to_previous_page;
+	my $can_move_forward = $self->view->can_move_to_next_page;
+	my $can_move_back = $self->view->can_move_to_previous_page;
 
 	for my $button_name ( qw(button-last button-forward) ) {
 		$self->builder->get_object($button_name)

--- a/lib/Renard/Curie/Component/PageDrawingArea.pm
+++ b/lib/Renard/Curie/Component/PageDrawingArea.pm
@@ -20,8 +20,6 @@ has view => (
 	required => 1
 );
 
-method zoom_level() { $self->view->zoom_level }
-
 =attr drawing_area
 
 The L<Gtk3::DrawingArea> that is used to draw the document on.
@@ -273,14 +271,14 @@ handlers.
 callback on_scroll_event_cb($window, $event, $self) {
 	if ( $event->state == 'control-mask' && $event->direction eq 'smooth') {
 		my ($delta_x, $delta_y) =  $event->get_scroll_deltas();
-		if ( $delta_y < 0 ) { $self->zoom_level ( $self->zoom_level - .05 ); }
-		elsif ( $delta_y > 0 ) { $self->zoom_level ( $self->zoom_level + .05 ); }
+		if ( $delta_y < 0 ) { $self->view->zoom_level ( $self->view->zoom_level - .05 ); }
+		elsif ( $delta_y > 0 ) { $self->view->zoom_level ( $self->view->zoom_level + .05 ); }
 		return 1;
 	} elsif ( $event->state == 'control-mask' && $event->direction eq 'up' ) {
-		$self->zoom_level ( $self->zoom_level + .05 );
+		$self->view->zoom_level ( $self->view->zoom_level + .05 );
 		return 1;
 	} elsif ( $event->state == 'control-mask' && $event->direction eq 'down' ) {
-		$self->zoom_level ( $self->zoom_level - .05 );
+		$self->view->zoom_level ( $self->view->zoom_level - .05 );
 		return 1;
 	}
 	return 0;

--- a/lib/Renard/Curie/Component/PageDrawingArea.pm
+++ b/lib/Renard/Curie/Component/PageDrawingArea.pm
@@ -20,7 +20,6 @@ has view => (
 	required => 1
 );
 
-method document() { $self->view->document }
 method current_page_number() { $self->view->page_number }
 method zoom_level() { $self->view->zoom_level }
 

--- a/lib/Renard/Curie/Component/PageDrawingArea.pm
+++ b/lib/Renard/Curie/Component/PageDrawingArea.pm
@@ -23,7 +23,8 @@ TODO
 =cut
 has view => (
 	is => 'rw',
-	required => 1
+	required => 1,
+	trigger => 1,
 );
 
 =attr drawing_area
@@ -85,17 +86,6 @@ Initialises the component's contained widgets and signals.
 
 =cut
 method BUILD(@) {
-	# so that the widget can take input
-	$self->view->signal_connect( 'view-changed', sub {
-		$self->signal_emit('update-scroll-adjustment');
-		if( $self->view->can('get_size_request') ) {
-			$self->drawing_area->set_size_request(
-				$self->view->get_size_request
-			);
-		} else {
-			$self->refresh_drawing_area;
-		}
-	} );
 	$self->signal_connect( 'update-scroll-adjustment', sub {
 		if( $self->view->can('update_scroll_adjustment') ) {
 			$self->view->update_scroll_adjustment(
@@ -418,6 +408,25 @@ method set_navigation_buttons_sensitivity() {
 		$self->builder->get_object($button_name)
 			->set_sensitive($can_move_back);
 	}
+}
+
+method _trigger_view($new_view) {
+	# so that the widget can take input
+	$self->view->signal_connect( 'view-changed', sub {
+		$self->signal_emit('update-scroll-adjustment');
+		if( $self->view->can('get_size_request') ) {
+			if( $self->drawing_area ) {
+				$self->drawing_area->set_size_request(
+					$self->view->get_size_request
+				);
+				$self->refresh_drawing_area;
+			}
+		} else {
+			$self->refresh_drawing_area;
+		}
+	} );
+
+	$self->view->signal_emit('view-changed');
 }
 
 with qw(

--- a/lib/Renard/Curie/Component/PageDrawingArea.pm
+++ b/lib/Renard/Curie/Component/PageDrawingArea.pm
@@ -72,8 +72,8 @@ Initialises the component's contained widgets and signals.
 
 =cut
 method BUILD(@) {
-	$self->view->_pd($self); # HACK TODO
 	# so that the widget can take input
+	$self->view->signal_connect( 'view-changed', sub { $self->refresh_drawing_area } );
 	$self->set_can_focus( TRUE );
 
 	$self->setup_button_events;

--- a/lib/Renard/Curie/Component/PageDrawingArea.pm
+++ b/lib/Renard/Curie/Component/PageDrawingArea.pm
@@ -9,6 +9,7 @@ use Renard::Curie::Types qw(RenderableDocumentModel RenderablePageModel
 	PageNumber ZoomLevel Bool InstanceOf);
 use Function::Parameters;
 use Renard::Curie::Model::View::SinglePage;
+use Renard::Curie::Model::View::ContinuousPage;
 
 =attr view
 
@@ -45,7 +46,7 @@ around BUILDARGS => sub {
 
 	if( exists $args{document} ) {
 		my $doc = delete $args{document};
-		$args{view} = Renard::Curie::Model::View::SinglePage->new(
+		$args{view} = Renard::Curie::Model::View::ContinuousPage->new(
 			document => $doc,
 		);
 	}

--- a/lib/Renard/Curie/Data/PDF.pm
+++ b/lib/Renard/Curie/Data/PDF.pm
@@ -144,7 +144,7 @@ Simplified, the high-level structure looks like:
               <span> -> [list of spans] (horizontal spaces over a line)
                 <char> -> [list of chars]
         - image
-            TODO
+            # TODO document the image data from mutool
 
 =cut
 fun get_mutool_text_stext_raw($pdf_filename, $pdf_page_no) {
@@ -175,15 +175,6 @@ fun get_mutool_text_stext_xml($pdf_filename, $pdf_page_no) {
 		$pdf_filename,
 		$pdf_page_no,
 	);
-	# page -> [list of blocks]
-	#   block -> [list of blocks]
-	#     block is either:
-	#       - stext
-	#           line -> [list of lines] (all have same baseline)
-	#             span -> [list of spans] (horizontal spaces over a line)
-	#               char -> [list of chars]
-	#       - image
-	#           TODO
 
 	my $stext = XMLin( $stext_xml,
 		ForceArray => [ qw(page block line span char) ] );

--- a/lib/Renard/Curie/Model/Document/CairoImageSurface.pm
+++ b/lib/Renard/Curie/Model/Document/CairoImageSurface.pm
@@ -20,6 +20,16 @@ has image_surfaces => (
 	required => 1
 );
 
+
+=attr identity_bounds
+
+TODO
+
+=cut
+has identity_bounds => (
+	is => 'lazy', # _build_identity_bounds
+);
+
 method _build_last_page_number() :ReturnType(PageNumber) {
 	return scalar @{ $self->image_surfaces };
 }
@@ -40,6 +50,22 @@ method get_rendered_page( (PageNumber) :$page_number, @) {
 		page_number => $page_number,
 		cairo_image_surface => $self->image_surfaces->[$index],
 	);
+}
+
+method _build_identity_bounds() {
+	my $surfaces = $self->image_surfaces;
+	return [ map {
+		{
+			x => $surfaces->[$_]->get_height,
+			y => $surfaces->[$_]->get_width,
+			rotate => 0,
+			pageno => $_ + 1,
+			dims => {
+				w => $surfaces->[$_]->get_width,
+				h => $surfaces->[$_]->get_height,
+			},
+		}
+	} 0..@$surfaces-1 ];
 }
 
 extends qw(Renard::Curie::Model::Document);

--- a/lib/Renard/Curie/Model/Document/CairoImageSurface.pm
+++ b/lib/Renard/Curie/Model/Document/CairoImageSurface.pm
@@ -20,16 +20,6 @@ has image_surfaces => (
 	required => 1
 );
 
-
-=attr identity_bounds
-
-TODO
-
-=cut
-has identity_bounds => (
-	is => 'lazy', # _build_identity_bounds
-);
-
 method _build_last_page_number() :ReturnType(PageNumber) {
 	return scalar @{ $self->image_surfaces };
 }
@@ -73,6 +63,7 @@ extends qw(Renard::Curie::Model::Document);
 with qw(
 	Renard::Curie::Model::Document::Role::Pageable
 	Renard::Curie::Model::Document::Role::Renderable
+	Renard::Curie::Model::Document::Role::Boundable
 );
 
 1;

--- a/lib/Renard/Curie/Model/Document/PDF.pm
+++ b/lib/Renard/Curie/Model/Document/PDF.pm
@@ -56,6 +56,12 @@ method _build_outline() {
 	return Renard::Curie::Model::Outline->new( items => $outline_data );
 }
 
+method get_bounds() {
+	my $info = Renard::Curie::Data::PDF::get_mutool_page_info_xml(
+		$self->filename
+	);
+}
+
 with qw(
 	Renard::Curie::Model::Document::Role::FromFile
 	Renard::Curie::Model::Document::Role::Pageable

--- a/lib/Renard/Curie/Model/Document/PDF.pm
+++ b/lib/Renard/Curie/Model/Document/PDF.pm
@@ -19,10 +19,6 @@ has _raw_bounds => (
 	is => 'lazy', # _build_raw_bounds
 );
 
-has identity_bounds => (
-	is => 'lazy', # _build_identity_bounds
-);
-
 =begin comment
 
 =method _build_last_page_number
@@ -125,6 +121,7 @@ with qw(
 	Renard::Curie::Model::Document::Role::Renderable
 	Renard::Curie::Model::Document::Role::Cacheable
 	Renard::Curie::Model::Document::Role::Outlineable
+	Renard::Curie::Model::Document::Role::Boundable
 );
 
 1;

--- a/lib/Renard/Curie/Model/Document/Role/Boundable.pm
+++ b/lib/Renard/Curie/Model/Document/Role/Boundable.pm
@@ -1,0 +1,19 @@
+use Renard::Curie::Setup;
+package Renard::Curie::Model::Document::Role::Boundable;
+# ABSTRACT: Role for documents where each page has bounds
+
+use Moo::Role;
+use Renard::Curie::Types qw(ArrayRef HashRef);
+
+=attr identity_bounds
+
+An C<ArrayRef[HashRef]> of data that gives information about the bounds of each page of
+the document.
+
+=cut
+has identity_bounds => (
+	is => 'lazy', # _build_identity_bounds
+	isa => ArrayRef[HashRef],
+);
+
+1;

--- a/lib/Renard/Curie/Model/Document/Role/Pageable.pm
+++ b/lib/Renard/Curie/Model/Document/Role/Pageable.pm
@@ -37,6 +37,7 @@ first and last page numbers inclusive.
 
 =cut
 method is_valid_page_number( $page_number ) :ReturnType(Bool) {
+	# uncoverable condition right
 	PageNumber->check($page_number)
 		&& $page_number >= $self->first_page_number
 		&& $page_number <= $self->last_page_number

--- a/lib/Renard/Curie/Model/Page/Role/Zoomable.pm
+++ b/lib/Renard/Curie/Model/Page/Role/Zoomable.pm
@@ -1,6 +1,0 @@
-use Renard::Curie::Setup;
-package Renard::Curie::Model::Page::Role::Zoomable;
-
-# TODO
-
-1;

--- a/lib/Renard/Curie/Model/View/ContinuousPage.pm
+++ b/lib/Renard/Curie/Model/View/ContinuousPage.pm
@@ -38,6 +38,7 @@ method draw_page(
 	(InstanceOf['Gtk3::DrawingArea']) $widget,
 	(InstanceOf['Cairo::Context']) $cr
 ) {
+	# uncoverable subroutine
 	my $p =  $widget->get_parent;
 	my $v = $p->get_vadjustment;
 

--- a/lib/Renard/Curie/Model/View/ContinuousPage.pm
+++ b/lib/Renard/Curie/Model/View/ContinuousPage.pm
@@ -1,0 +1,173 @@
+use Renard::Curie::Setup;
+package Renard::Curie::Model::View::ContinuousPage;
+# ABSTRACT: TODO
+
+use Moo;
+use Renard::Curie::Types qw(RenderablePageModel InstanceOf);
+use Math::Trig;
+use Math::Polygon;
+
+use Glib::Object::Subclass
+	Glib::Object::,
+	signals => { 'view-changed' => {} },
+	;
+
+has bounds => ( is => 'lazy' ); # _build_bounds
+
+method _build_bounds() {
+	my $compute_rotate_dim = sub {
+		my ($info) = @_;
+		my $theta_deg = $info->{rotate} // 0;
+		my $theta_rad = $theta_deg * pi / 180;
+
+		my ($x, $y) = ($info->{x}, $info->{y});
+		my $poly = Math::Polygon->new(
+			points => [
+				[0, 0],
+				[$x, 0],
+				[$x, $y],
+				[0, $y],
+			],
+		);
+
+		my $rotated_poly = $poly->rotate(
+			degrees => $theta_deg,
+			center => [ $x/2, $y/2 ],
+		);
+
+		my ($xmin, $ymin, $xmax, $ymax) = $rotated_poly->bbox;
+
+
+		return { w => $xmax - $xmin, h => $ymax - $ymin };
+	};
+
+	my $bounds = $self->document->get_bounds;
+	my @page_xy = map {
+		my $p = {
+			x => $_->{MediaBox}{r},
+			y => $_->{MediaBox}{t},
+			rotate => $_->{Rotate}{v} // 0,
+			pageno => $_->{pagenum},
+		};
+		if( exists $p->{rotate} ) {
+			$p->{dims} = $compute_rotate_dim->( $p );
+		}
+
+		$p;
+	} @{ $bounds->{page} };
+
+	return \@page_xy;
+}
+
+=head1 SIGNALS
+
+=for :list
+* C<view-changed>: called when a view property is changed.
+
+=cut
+
+=classmethod FOREIGNBUILDARGS
+
+  classmethod FOREIGNBUILDARGS(@)
+
+Initialises the L<Glib::Object> super-class.
+
+=cut
+classmethod FOREIGNBUILDARGS(@) {
+	return ();
+}
+
+=method draw_page
+
+TODO
+
+=cut
+method draw_page(
+	(InstanceOf['Gtk3::DrawingArea']) $widget,
+	(InstanceOf['Cairo::Context']) $cr
+) {
+	my $p =  $widget->get_parent;
+	my $v = $p->get_vadjustment;
+
+	my $view_y_min = $v->get_value;
+	my $view_y_max = $v->get_value + $v->get_page_size;
+
+	my $interpage = 10;
+	my $page_xy = $self->bounds;
+	my $largest_x = 0;
+	my $y_so_far = 0;
+	for my $page (@$page_xy) {
+
+		$page->{bbox} = [-1, -1, -1, -1];
+
+		# xmin
+		$page->{bbox}[0] = ($widget->get_allocated_width - $page->{dims}{w}) / 2;
+		# ymin
+		$page->{bbox}[1] = $y_so_far;
+		# xmax
+		$page->{bbox}[2] = $page->{bbox}[0] + $page->{dims}{w};
+		# ymax
+		$page->{bbox}[3] = $y_so_far + $page->{dims}{h};
+
+		if( $page->{dims}{w} > $largest_x ) {
+			$largest_x = $page->{dims}{w};
+		}
+
+		$y_so_far += $page->{dims}{h} + $interpage;
+	}
+	my $total_y = $y_so_far - $interpage;
+
+
+	my $zoom_level = $self->zoom_level;
+	for my $page (@$page_xy) {
+		next if $page->{bbox}[3] < $view_y_min
+			|| $page->{bbox}[1] > $view_y_max;
+
+		my $rp = $self->document->get_rendered_page(
+			page_number => $page->{pageno},
+			zoom_level => $zoom_level,
+		);
+
+		my $img = $rp->cairo_image_surface;
+
+		$cr->set_source_surface($img,
+			$page->{bbox}[0],
+			$page->{bbox}[1]);
+
+		$cr->paint;
+	}
+
+	$widget->set_size_request(
+		$largest_x,
+		$total_y );
+
+=begin comment
+
+	my $img = $rp->cairo_image_surface;
+
+	$cr->set_source_surface($img, ($widget->get_allocated_width -
+		$rp->width) / 2, 0);
+	$cr->paint;
+
+	$widget->set_size_request(
+		$rp->width,
+		$rp->height );
+
+=cut
+}
+
+method _trigger_page_number($new_page_number) {
+	$self->signal_emit( 'view-changed' );
+}
+
+method _trigger_zoom_level($new_zoom_level) {
+	$self->signal_emit( 'view-changed' );
+}
+
+with qw(
+	Renard::Curie::Model::View::Role::ForDocument
+	Renard::Curie::Model::View::Role::Pageable
+	Renard::Curie::Model::View::Role::Zoomable
+);
+
+1;

--- a/lib/Renard/Curie/Model/View/ContinuousPage.pm
+++ b/lib/Renard/Curie/Model/View/ContinuousPage.pm
@@ -4,6 +4,7 @@ package Renard::Curie::Model::View::ContinuousPage;
 
 use Moo;
 use Renard::Curie::Types qw(RenderablePageModel InstanceOf);
+use POSIX qw(ceil);
 
 use Glib::Object::Subclass
 	'Glib::Object',
@@ -43,32 +44,12 @@ method draw_page(
 	my $view_y_min = $v->get_value;
 	my $view_y_max = $v->get_value + $v->get_page_size;
 
-	my $interpage = 10;
-	my $page_xy = $self->document->identity_bounds;
-	my $largest_x = 0;
-	my $y_so_far = 0;
-	for my $page (@$page_xy) {
-
-		$page->{bbox} = [-1, -1, -1, -1];
-
-		# xmin
-		$page->{bbox}[0] = ($widget->get_allocated_width - $page->{dims}{w}) / 2;
-		# ymin
-		$page->{bbox}[1] = $y_so_far;
-		# xmax
-		$page->{bbox}[2] = $page->{bbox}[0] + $page->{dims}{w};
-		# ymax
-		$page->{bbox}[3] = $y_so_far + $page->{dims}{h};
-
-		if( $page->{dims}{w} > $largest_x ) {
-			$largest_x = $page->{dims}{w};
-		}
-
-		$y_so_far += $page->{dims}{h} + $interpage;
-	}
-	my $total_y = $y_so_far - $interpage;
-
-
+	$self->widget_dims([
+		$widget->get_allocated_width,
+		$widget->get_allocated_height,
+	]);
+	$self->_clear_page_info;
+	my $page_xy = $self->_page_info->{page_xy};
 	my $zoom_level = $self->zoom_level;
 	for my $page (@$page_xy) {
 		next if $page->{bbox}[3] < $view_y_min
@@ -87,10 +68,6 @@ method draw_page(
 
 		$cr->paint;
 	}
-
-	$widget->set_size_request(
-		$largest_x,
-		$total_y );
 
 =begin comment
 
@@ -112,7 +89,59 @@ method _trigger_page_number($new_page_number) {
 }
 
 method _trigger_zoom_level($new_zoom_level) {
+	$self->_clear_page_info;
 	$self->signal_emit( 'view-changed' );
+}
+
+has widget_dims => (
+	is => 'rw',
+	default => sub { [0, 0] },
+);
+
+has _page_info => (
+	is => 'lazy',
+	clearer => 1, # _clear_page_info
+);
+
+method _build__page_info() {
+	my $interpage = 10;
+	my $page_xy = $self->document->identity_bounds;
+	my $largest_x = 0;
+	my $y_so_far = 0;
+	for my $page (@$page_xy) {
+		# multiply to account for zoom-level
+		my $w = ceil($page->{dims}{w} * $self->zoom_level);
+		my $h = ceil($page->{dims}{h} * $self->zoom_level);
+
+		$page->{bbox} = [-1, -1, -1, -1];
+
+		# xmin
+		$page->{bbox}[0] = ($self->widget_dims->[0] - $w) / 2;
+		# ymin
+		$page->{bbox}[1] = $y_so_far;
+		# xmax
+		$page->{bbox}[2] = $page->{bbox}[0] + $w;
+		# ymax
+		$page->{bbox}[3] = $y_so_far + $h;
+
+		if( $w > $largest_x ) {
+			$largest_x = $w;
+		}
+
+		$y_so_far += $h + $interpage;
+	}
+	my $total_y = $y_so_far - $interpage;
+
+	return {
+		page_xy => $page_xy,
+		total_y => $total_y,
+		largest_x => $largest_x,
+	};
+}
+
+method get_size_request() {
+	my $page_info = $self->_page_info;
+	return ( $page_info->{largest_x}, $page_info->{total_y} );
 }
 
 with qw(

--- a/lib/Renard/Curie/Model/View/ContinuousPage.pm
+++ b/lib/Renard/Curie/Model/View/ContinuousPage.pm
@@ -1,9 +1,9 @@
 use Renard::Curie::Setup;
 package Renard::Curie::Model::View::ContinuousPage;
-# ABSTRACT: TODO
+# ABSTRACT: A view model for continuous page views
 
 use Moo;
-use Renard::Curie::Types qw(RenderablePageModel InstanceOf);
+use Renard::Curie::Types qw(RenderablePageModel InstanceOf SizeRequest);
 use POSIX qw(ceil);
 
 use Glib::Object::Subclass
@@ -31,7 +31,7 @@ classmethod FOREIGNBUILDARGS(@) {
 
 =method draw_page
 
-TODO
+See L<Renard::Curie::Model::View::Role::Renderable/draw_page>.
 
 =cut
 method draw_page(
@@ -44,7 +44,7 @@ method draw_page(
 	my $view_y_min = $v->get_value;
 	my $view_y_max = $v->get_value + $v->get_page_size;
 
-	$self->widget_dims([
+	$self->_widget_dims([
 		$widget->get_allocated_width,
 		$widget->get_allocated_height,
 	]);
@@ -68,20 +68,6 @@ method draw_page(
 
 		$cr->paint;
 	}
-
-=begin comment
-
-	my $img = $rp->cairo_image_surface;
-
-	$cr->set_source_surface($img, ($widget->get_allocated_width -
-		$rp->width) / 2, 0);
-	$cr->paint;
-
-	$widget->set_size_request(
-		$rp->width,
-		$rp->height );
-
-=cut
 }
 
 method _trigger_page_number($new_page_number) {
@@ -93,7 +79,7 @@ method _trigger_zoom_level($new_zoom_level) {
 	$self->signal_emit( 'view-changed' );
 }
 
-has widget_dims => (
+has _widget_dims => (
 	is => 'rw',
 	default => sub { [0, 0] },
 );
@@ -116,7 +102,7 @@ method _build__page_info() {
 		$page->{bbox} = [-1, -1, -1, -1];
 
 		# xmin
-		$page->{bbox}[0] = ($self->widget_dims->[0] - $w) / 2;
+		$page->{bbox}[0] = ($self->_widget_dims->[0] - $w) / 2;
 		# ymin
 		$page->{bbox}[1] = $y_so_far;
 		# xmax
@@ -139,7 +125,12 @@ method _build__page_info() {
 	};
 }
 
-method get_size_request() {
+=method get_size_request
+
+See L<Renard::Curie::Model::View::Role::Renderable/get_size_request>.
+
+=cut
+method get_size_request() :ReturnType( list => SizeRequest) {
 	my $page_info = $self->_page_info;
 	return ( $page_info->{largest_x}, $page_info->{total_y} );
 }
@@ -148,6 +139,7 @@ with qw(
 	Renard::Curie::Model::View::Role::ForDocument
 	Renard::Curie::Model::View::Role::Pageable
 	Renard::Curie::Model::View::Role::Zoomable
+	Renard::Curie::Model::View::Role::Renderable
 );
 
 1;

--- a/lib/Renard/Curie/Model/View/ContinuousPage.pm
+++ b/lib/Renard/Curie/Model/View/ContinuousPage.pm
@@ -8,7 +8,7 @@ use Math::Trig;
 use Math::Polygon;
 
 use Glib::Object::Subclass
-	Glib::Object::,
+	'Glib::Object',
 	signals => { 'view-changed' => {} },
 	;
 

--- a/lib/Renard/Curie/Model/View/Role/ForDocument.pm
+++ b/lib/Renard/Curie/Model/View/Role/ForDocument.pm
@@ -1,0 +1,20 @@
+use Renard::Curie::Setup;
+package Renard::Curie::Model::View::Role::ForDocument;
+# ABSTRACT: TODO
+
+use Moo::Role;
+use Renard::Curie::Types qw(RenderableDocumentModel);
+
+=attr document
+
+The L<RenderableDocumentModel|Renard:Curie::Types/RenderableDocumentModel> that
+this component displays.
+
+=cut
+has document => (
+	is => 'rw',
+	isa => RenderableDocumentModel,
+	required => 1
+);
+
+1;

--- a/lib/Renard/Curie/Model/View/Role/ForDocument.pm
+++ b/lib/Renard/Curie/Model/View/Role/ForDocument.pm
@@ -1,6 +1,6 @@
 use Renard::Curie::Setup;
 package Renard::Curie::Model::View::Role::ForDocument;
-# ABSTRACT: TODO
+# ABSTRACT: Role for view model based on a document
 
 use Moo::Role;
 use Renard::Curie::Types qw(RenderableDocumentModel);
@@ -8,7 +8,7 @@ use Renard::Curie::Types qw(RenderableDocumentModel);
 =attr document
 
 The L<RenderableDocumentModel|Renard:Curie::Types/RenderableDocumentModel> that
-this component displays.
+this view model represents.
 
 =cut
 has document => (

--- a/lib/Renard/Curie/Model/View/Role/Pageable.pm
+++ b/lib/Renard/Curie/Model/View/Role/Pageable.pm
@@ -3,7 +3,34 @@ package Renard::Curie::Model::View::Role::Pageable;
 # ABSTRACT: TODO
 
 use Moo::Role;
-use Renard::Curie::Types qw(Bool);
+use Renard::Curie::Types qw(Bool PageNumber);
+
+=attr page_number
+
+A L<PageNumber|Renard:Curie::Types/PageNumber> for the current page being
+drawn.
+
+=cut
+has page_number => (
+	is => 'rw',
+	isa => PageNumber,
+	default => 1,
+	trigger => 1 # _trigger_page_number
+	);
+
+=begin comment
+
+=method _trigger_page_number
+
+  method _trigger_page_number($new_page_number)
+
+Called whenever the L</page_number> is changed. This allows for telling
+the component to retrieve the new page and redraw.
+
+=end comment
+
+=cut
+requires '_trigger_page_number';
 
 =method set_current_page_to_first
 

--- a/lib/Renard/Curie/Model/View/Role/Pageable.pm
+++ b/lib/Renard/Curie/Model/View/Role/Pageable.pm
@@ -1,0 +1,78 @@
+use Renard::Curie::Setup;
+package Renard::Curie::Model::View::Role::Pageable;
+# ABSTRACT: TODO
+
+use Moo::Role;
+use Renard::Curie::Types qw(Bool);
+
+=method set_current_page_to_first
+
+  method set_current_page_to_first()
+
+Sets the page number to the first page of the document.
+
+=cut
+method set_current_page_to_first() {
+	$self->page_number( $self->document->first_page_number );
+}
+
+=method set_current_page_to_last
+
+  method set_current_page_to_last()
+
+Sets the current page to the last page of the document.
+
+=cut
+method set_current_page_to_last() {
+	$self->page_number( $self->document->last_page_number );
+}
+
+=method can_move_to_previous_page
+
+  method can_move_to_previous_page() :ReturnType(Bool)
+
+Predicate to check if we can decrement the current page number.
+
+=cut
+method can_move_to_previous_page() :ReturnType(Bool) {
+	$self->page_number > $self->document->first_page_number;
+}
+
+=method can_move_to_next_page
+
+  method can_move_to_next_page() :ReturnType(Bool)
+
+Predicate to check if we can increment the current page number.
+
+=cut
+method can_move_to_next_page() :ReturnType(Bool) {
+	$self->page_number < $self->document->last_page_number;
+}
+
+=method set_current_page_forward
+
+  method set_current_page_forward()
+
+Increments the current page number if possible.
+
+=cut
+method set_current_page_forward() {
+	if( $self->can_move_to_next_page ) {
+		$self->page_number( $self->page_number + 1 );
+	}
+}
+
+=method set_current_page_back
+
+  method set_current_page_back()
+
+Decrements the current page number if possible.
+
+=cut
+method set_current_page_back() {
+	if( $self->can_move_to_previous_page ) {
+		$self->page_number( $self->page_number - 1 );
+	}
+}
+
+1;

--- a/lib/Renard/Curie/Model/View/Role/Pageable.pm
+++ b/lib/Renard/Curie/Model/View/Role/Pageable.pm
@@ -1,6 +1,6 @@
 use Renard::Curie::Setup;
 package Renard::Curie::Model::View::Role::Pageable;
-# ABSTRACT: TODO
+# ABSTRACT: Role for view models that are paged
 
 use Moo::Role;
 use Renard::Curie::Types qw(Bool PageNumber);

--- a/lib/Renard/Curie/Model/View/Role/Renderable.pm
+++ b/lib/Renard/Curie/Model/View/Role/Renderable.pm
@@ -1,0 +1,29 @@
+use Renard::Curie::Setup;
+package Renard::Curie::Model::View::Role::Renderable;
+# ABSTRACT: Role for rendering a view model
+
+use Moo::Role;
+use Renard::Curie::Types qw(InstanceOf SizeRequest);
+
+=method draw_page
+
+Draws the pages for the current view model to a C<Gtk3::DrawingArea>.
+
+=cut
+method draw_page(
+	(InstanceOf['Gtk3::DrawingArea']) $widget,
+	(InstanceOf['Cairo::Context']) $cr
+) {
+	...
+}
+
+=method get_size_request
+
+Determines the size request for the current view.
+
+=cut
+method get_size_request() :ReturnType( list => SizeRequest) {
+	...
+}
+
+1;

--- a/lib/Renard/Curie/Model/View/Role/Renderable.pm
+++ b/lib/Renard/Curie/Model/View/Role/Renderable.pm
@@ -14,7 +14,8 @@ method draw_page(
 	(InstanceOf['Gtk3::DrawingArea']) $widget,
 	(InstanceOf['Cairo::Context']) $cr
 ) {
-	...
+	# uncoverable subroutine
+	... # uncoverable statement
 }
 
 =method get_size_request
@@ -23,7 +24,8 @@ Determines the size request for the current view.
 
 =cut
 method get_size_request() :ReturnType( list => SizeRequest) {
-	...
+	# uncoverable subroutine
+	... # uncoverable statement
 }
 
 1;

--- a/lib/Renard/Curie/Model/View/Role/Zoomable.pm
+++ b/lib/Renard/Curie/Model/View/Role/Zoomable.pm
@@ -1,0 +1,35 @@
+use Renard::Curie::Setup;
+package Renard::Curie::Model::View::Role::Zoomable;
+# ABSTRACT: TODO
+
+use Moo::Role;
+use Renard::Curie::Types qw(ZoomLevel);
+
+=attr zoom_level
+
+A L<ZoomLevel|Renard::Curie::Types/ZoomLevel> for the current zoom level for
+the document.
+
+=cut
+has zoom_level => (
+	is => 'rw',
+	isa => ZoomLevel,
+	default => 1.0,
+	trigger => 1 # _trigger_zoom_level
+	);
+
+=begin comment
+
+=method _trigger_zoom_level
+
+  method _trigger_zoom_level($new_zoom_level)
+
+Called whenever the L</zoom_level> is changed. This tells the component to
+redraw the current page at the new zoom level.
+
+=end comment
+
+=cut
+requires '_trigger_zoom_level';
+
+1;

--- a/lib/Renard/Curie/Model/View/Role/Zoomable.pm
+++ b/lib/Renard/Curie/Model/View/Role/Zoomable.pm
@@ -1,6 +1,6 @@
 use Renard::Curie::Setup;
 package Renard::Curie::Model::View::Role::Zoomable;
-# ABSTRACT: TODO
+# ABSTRACT: Role for view models that support zooming
 
 use Moo::Role;
 use Renard::Curie::Types qw(ZoomLevel);

--- a/lib/Renard/Curie/Model/View/SinglePage.pm
+++ b/lib/Renard/Curie/Model/View/SinglePage.pm
@@ -10,7 +10,23 @@ use Glib::Object::Subclass
 	signals => { 'view-changed' => {} },
 	;
 
-sub FOREIGNBUILDARGS { () }
+=head1 SIGNALS
+
+=for :list
+* C<view-changed>: called when a view property is changed.
+
+=cut
+
+=classmethod FOREIGNBUILDARGS
+
+  classmethod FOREIGNBUILDARGS(@)
+
+Initialises the L<Glib::Object> super-class.
+
+=cut
+classmethod FOREIGNBUILDARGS(@) {
+	return ();
+}
 
 
 =attr document

--- a/lib/Renard/Curie/Model/View/SinglePage.pm
+++ b/lib/Renard/Curie/Model/View/SinglePage.pm
@@ -115,4 +115,75 @@ method draw_page(
 		$rp->height );
 }
 
+=method set_current_page_to_first
+
+  method set_current_page_to_first()
+
+Sets the page number to the first page of the document.
+
+=cut
+method set_current_page_to_first() {
+	$self->page_number( $self->document->first_page_number );
+}
+
+=method set_current_page_to_last
+
+  method set_current_page_to_last()
+
+Sets the current page to the last page of the document.
+
+=cut
+method set_current_page_to_last() {
+	$self->page_number( $self->document->last_page_number );
+}
+
+=method can_move_to_previous_page
+
+  method can_move_to_previous_page() :ReturnType(Bool)
+
+Predicate to check if we can decrement the current page number.
+
+=cut
+method can_move_to_previous_page() :ReturnType(Bool) {
+	$self->page_number > $self->document->first_page_number;
+}
+
+=method can_move_to_next_page
+
+  method can_move_to_next_page() :ReturnType(Bool)
+
+Predicate to check if we can increment the current page number.
+
+=cut
+method can_move_to_next_page() :ReturnType(Bool) {
+	$self->page_number < $self->document->last_page_number;
+}
+
+=method set_current_page_forward
+
+  method set_current_page_forward()
+
+Increments the current page number if possible.
+
+=cut
+method set_current_page_forward() {
+	if( $self->can_move_to_next_page ) {
+		$self->page_number( $self->page_number + 1 );
+	}
+}
+
+=method set_current_page_back
+
+  method set_current_page_back()
+
+Decrements the current page number if possible.
+
+=cut
+method set_current_page_back() {
+	if( $self->can_move_to_previous_page ) {
+		$self->page_number( $self->page_number - 1 );
+	}
+}
+
+
 1;

--- a/lib/Renard/Curie/Model/View/SinglePage.pm
+++ b/lib/Renard/Curie/Model/View/SinglePage.pm
@@ -3,13 +3,14 @@ package Renard::Curie::Model::View::SinglePage;
 # ABSTRACT: TODO
 
 use Moo;
-use Renard::Curie::Types qw(RenderableDocumentModel RenderablePageModel
-	PageNumber ZoomLevel Bool InstanceOf);
+use Renard::Curie::Types qw(RenderablePageModel InstanceOf RenderableDocumentModel PageNumber ZoomLevel);
 
-# HACK TODO
-has _pd => (
-	is => 'rw',
-);
+use Glib::Object::Subclass
+	Glib::Object::,
+	signals => { 'view-changed' => {} },
+	;
+
+sub FOREIGNBUILDARGS { () }
 
 
 =attr document
@@ -64,7 +65,6 @@ method rendered_page() :ReturnType(RenderablePageModel) {
 }
 
 
-# HACK TODO
 =begin comment
 
 =method _trigger_page_number
@@ -78,10 +78,9 @@ the component to retrieve the new page and redraw.
 
 =cut
 method _trigger_page_number($new_page_number) {
-	$self->_pd->refresh_drawing_area;
+	$self->signal_emit( 'view-changed' );
 }
 
-# HACK TODO
 =begin comment
 
 =method _trigger_zoom_level
@@ -95,9 +94,14 @@ redraw the current page at the new zoom level.
 
 =cut
 method _trigger_zoom_level($new_zoom_level) {
-	$self->_pd->refresh_drawing_area;
+	$self->signal_emit( 'view-changed' );
 }
 
+=method draw_page
+
+TODO
+
+=cut
 method draw_page(
 	(InstanceOf['Gtk3::DrawingArea']) $widget,
 	(InstanceOf['Cairo::Context']) $cr

--- a/lib/Renard/Curie/Model/View/SinglePage.pm
+++ b/lib/Renard/Curie/Model/View/SinglePage.pm
@@ -1,0 +1,101 @@
+use Renard::Curie::Setup;
+package Renard::Curie::Model::View::SinglePage;
+# ABSTRACT: TODO
+
+use Moo;
+use Renard::Curie::Types qw(RenderableDocumentModel RenderablePageModel
+	PageNumber ZoomLevel Bool InstanceOf);
+
+# HACK TODO
+has _pd => (
+	is => 'rw',
+);
+
+
+=attr document
+
+The L<RenderableDocumentModel|Renard:Curie::Types/RenderableDocumentModel> that
+this component displays.
+
+=cut
+has document => (
+	is => 'rw',
+	isa => RenderableDocumentModel,
+	required => 1
+);
+
+=attr page_number
+
+A L<PageNumber|Renard:Curie::Types/PageNumber> for the current page being
+drawn.
+
+=cut
+has page_number => (
+	is => 'rw',
+	isa => PageNumber,
+	default => 1,
+	trigger => 1 # _trigger_page_number
+	);
+
+=attr zoom_level
+
+A L<ZoomLevel|Renard::Curie::Types/ZoomLevel> for the current zoom level for
+the document.
+
+=cut
+has zoom_level => (
+	is => 'rw',
+	isa => ZoomLevel,
+	default => 1.0,
+	trigger => 1 # _trigger_zoom_level
+	);
+
+=attr rendered_page
+
+A L<RenderablePageModel|Renard:Curie::Types/RenderablePageModel> for the
+current page.
+
+=cut
+method rendered_page() :ReturnType(RenderablePageModel) {
+	my $rp = $self->document->get_rendered_page(
+		page_number => $self->page_number,
+		zoom_level => $self->zoom_level,
+	);
+}
+
+
+# HACK TODO
+=begin comment
+
+=method _trigger_page_number
+
+  method _trigger_page_number($new_page_number)
+
+Called whenever the L</page_number> is changed. This allows for telling
+the component to retrieve the new page and redraw.
+
+=end comment
+
+=cut
+method _trigger_page_number($new_page_number) {
+	$self->_pd->refresh_drawing_area;
+}
+
+# HACK TODO
+=begin comment
+
+=method _trigger_zoom_level
+
+  method _trigger_zoom_level($new_zoom_level)
+
+Called whenever the L</zoom_level> is changed. This tells the component to
+redraw the current page at the new zoom level.
+
+=end comment
+
+=cut
+method _trigger_zoom_level($new_zoom_level) {
+	$self->_pd->refresh_drawing_area;
+}
+
+1;

--- a/lib/Renard/Curie/Model/View/SinglePage.pm
+++ b/lib/Renard/Curie/Model/View/SinglePage.pm
@@ -3,7 +3,7 @@ package Renard::Curie::Model::View::SinglePage;
 # ABSTRACT: TODO
 
 use Moo;
-use Renard::Curie::Types qw(RenderablePageModel InstanceOf RenderableDocumentModel PageNumber ZoomLevel);
+use Renard::Curie::Types qw(RenderablePageModel InstanceOf);
 
 use Glib::Object::Subclass
 	Glib::Object::,
@@ -70,6 +70,23 @@ method draw_page(
 	$widget->set_size_request(
 		$rp->width,
 		$rp->height );
+}
+
+method update_scroll_adjustment(
+	(InstanceOf['Gtk3::Adjustment']) $hadjustment,
+	(InstanceOf['Gtk3::Adjustment']) $vadjustment,
+	) {
+
+	say join "; ",
+		map {
+			my $list = join ", ", (
+				$_->get_lower,
+				$_->get_value,
+				$_->get_value + $_->get_page_size,
+				$_->get_upper,
+			);
+			"[ $list ]";
+		} ($hadjustment, $vadjustment);
 }
 
 with qw(

--- a/lib/Renard/Curie/Model/View/SinglePage.pm
+++ b/lib/Renard/Curie/Model/View/SinglePage.pm
@@ -115,75 +115,8 @@ method draw_page(
 		$rp->height );
 }
 
-=method set_current_page_to_first
-
-  method set_current_page_to_first()
-
-Sets the page number to the first page of the document.
-
-=cut
-method set_current_page_to_first() {
-	$self->page_number( $self->document->first_page_number );
-}
-
-=method set_current_page_to_last
-
-  method set_current_page_to_last()
-
-Sets the current page to the last page of the document.
-
-=cut
-method set_current_page_to_last() {
-	$self->page_number( $self->document->last_page_number );
-}
-
-=method can_move_to_previous_page
-
-  method can_move_to_previous_page() :ReturnType(Bool)
-
-Predicate to check if we can decrement the current page number.
-
-=cut
-method can_move_to_previous_page() :ReturnType(Bool) {
-	$self->page_number > $self->document->first_page_number;
-}
-
-=method can_move_to_next_page
-
-  method can_move_to_next_page() :ReturnType(Bool)
-
-Predicate to check if we can increment the current page number.
-
-=cut
-method can_move_to_next_page() :ReturnType(Bool) {
-	$self->page_number < $self->document->last_page_number;
-}
-
-=method set_current_page_forward
-
-  method set_current_page_forward()
-
-Increments the current page number if possible.
-
-=cut
-method set_current_page_forward() {
-	if( $self->can_move_to_next_page ) {
-		$self->page_number( $self->page_number + 1 );
-	}
-}
-
-=method set_current_page_back
-
-  method set_current_page_back()
-
-Decrements the current page number if possible.
-
-=cut
-method set_current_page_back() {
-	if( $self->can_move_to_previous_page ) {
-		$self->page_number( $self->page_number - 1 );
-	}
-}
-
+with qw(
+	Renard::Curie::Model::View::Role::Pageable
+);
 
 1;

--- a/lib/Renard/Curie/Model/View/SinglePage.pm
+++ b/lib/Renard/Curie/Model/View/SinglePage.pm
@@ -29,45 +29,7 @@ classmethod FOREIGNBUILDARGS(@) {
 }
 
 
-=attr document
-
-The L<RenderableDocumentModel|Renard:Curie::Types/RenderableDocumentModel> that
-this component displays.
-
-=cut
-has document => (
-	is => 'rw',
-	isa => RenderableDocumentModel,
-	required => 1
-);
-
-=attr page_number
-
-A L<PageNumber|Renard:Curie::Types/PageNumber> for the current page being
-drawn.
-
-=cut
-has page_number => (
-	is => 'rw',
-	isa => PageNumber,
-	default => 1,
-	trigger => 1 # _trigger_page_number
-	);
-
-=attr zoom_level
-
-A L<ZoomLevel|Renard::Curie::Types/ZoomLevel> for the current zoom level for
-the document.
-
-=cut
-has zoom_level => (
-	is => 'rw',
-	isa => ZoomLevel,
-	default => 1.0,
-	trigger => 1 # _trigger_zoom_level
-	);
-
-=attr rendered_page
+=method rendered_page
 
 A L<RenderablePageModel|Renard:Curie::Types/RenderablePageModel> for the
 current page.
@@ -80,35 +42,10 @@ method rendered_page() :ReturnType(RenderablePageModel) {
 	);
 }
 
-
-=begin comment
-
-=method _trigger_page_number
-
-  method _trigger_page_number($new_page_number)
-
-Called whenever the L</page_number> is changed. This allows for telling
-the component to retrieve the new page and redraw.
-
-=end comment
-
-=cut
 method _trigger_page_number($new_page_number) {
 	$self->signal_emit( 'view-changed' );
 }
 
-=begin comment
-
-=method _trigger_zoom_level
-
-  method _trigger_zoom_level($new_zoom_level)
-
-Called whenever the L</zoom_level> is changed. This tells the component to
-redraw the current page at the new zoom level.
-
-=end comment
-
-=cut
 method _trigger_zoom_level($new_zoom_level) {
 	$self->signal_emit( 'view-changed' );
 }
@@ -136,7 +73,9 @@ method draw_page(
 }
 
 with qw(
+	Renard::Curie::Model::View::Role::ForDocument
 	Renard::Curie::Model::View::Role::Pageable
+	Renard::Curie::Model::View::Role::Zoomable
 );
 
 1;

--- a/lib/Renard/Curie/Model/View/SinglePage.pm
+++ b/lib/Renard/Curie/Model/View/SinglePage.pm
@@ -98,4 +98,21 @@ method _trigger_zoom_level($new_zoom_level) {
 	$self->_pd->refresh_drawing_area;
 }
 
+method draw_page(
+	(InstanceOf['Gtk3::DrawingArea']) $widget,
+	(InstanceOf['Cairo::Context']) $cr
+) {
+	my $rp = $self->rendered_page;
+
+	my $img = $rp->cairo_image_surface;
+
+	$cr->set_source_surface($img, ($widget->get_allocated_width -
+		$rp->width) / 2, 0);
+	$cr->paint;
+
+	$widget->set_size_request(
+		$rp->width,
+		$rp->height );
+}
+
 1;

--- a/lib/Renard/Curie/Model/View/SinglePage.pm
+++ b/lib/Renard/Curie/Model/View/SinglePage.pm
@@ -6,7 +6,7 @@ use Moo;
 use Renard::Curie::Types qw(RenderablePageModel InstanceOf);
 
 use Glib::Object::Subclass
-	Glib::Object::,
+	'Glib::Object',
 	signals => { 'view-changed' => {} },
 	;
 

--- a/lib/Renard/Curie/Types.pm
+++ b/lib/Renard/Curie/Types.pm
@@ -7,13 +7,16 @@ use Type::Library 0.008 -base,
 		DocumentModel
 		RenderableDocumentModel
 		PageNumber
+		LaxPageNumber
+		ZoomLevel
+		SizeRequest
 	)];
 use Type::Utils -all;
 
 # Listed here so that scan-perl-deps can find them
 use Types::Path::Tiny      ();
 use Types::URI             ();
-use Types::Standard        ();
+use Types::Standard        qw(Tuple);
 use Types::Common::Numeric qw(PositiveInt PositiveOrZeroInt PositiveNum);
 
 use Type::Libraries;
@@ -88,5 +91,13 @@ The amount to zoom in on a page. This is a multiplier such that
 
 =cut
 declare "ZoomLevel", parent => PositiveNum;
+
+=type SizeRequest
+
+A tuple that represents a size request for a widget.
+
+=cut
+declare "SizeRequest",
+	parent => Tuple[PositiveInt,PositiveInt];
 
 1;

--- a/t/Renard/Curie/App.t
+++ b/t/Renard/Curie/App.t
@@ -105,10 +105,10 @@ subtest "Open document twice" => sub {
 	my $cairo_doc_b = CurieTestHelper->create_cairo_document;
 
 	$app->open_document($cairo_doc_a);
-	cmp_deeply $app->page_document_component->document, $cairo_doc_a, 'First document loaded';
+	cmp_deeply $app->page_document_component->view->document, $cairo_doc_a, 'First document loaded';
 
 	$app->open_document($cairo_doc_b);
-	cmp_deeply $app->page_document_component->document, $cairo_doc_b, 'Second document loaded';
+	cmp_deeply $app->page_document_component->view->document, $cairo_doc_b, 'Second document loaded';
 
 	undef $app;
 };
@@ -140,7 +140,7 @@ subtest "Drag and drop of file" => sub {
 
 	Renard::Curie::App::on_drag_data_received_cb( $app->content_box, @signal_args);
 
-	is(  $app->page_document_component->document->filename, "$pdf_ref_path", "Drag and drop opened correct file" );
+	is(  $app->page_document_component->view->document->filename, "$pdf_ref_path", "Drag and drop opened correct file" );
 
 	undef $app;
 };

--- a/t/Renard/Curie/Component/KeyBindings.t
+++ b/t/Renard/Curie/Component/KeyBindings.t
@@ -20,13 +20,13 @@ fun Key_Event( (InstanceOf['Renard::Curie::App']) $app, (Int) $key) {
 subtest 'Check that Page Down moves forward a page and Page Up moves back a page' => sub {
 	my ( $app, $page_comp ) = CurieTestHelper->create_app_with_document($cairo_doc);
 
-	is($page_comp->current_page_number, 1, 'Start on page 1' );
+	is($page_comp->view->page_number, 1, 'Start on page 1' );
 
 	Key_Event($app, Gtk3::Gdk::KEY_Page_Down);
-	is($page_comp->current_page_number, 2, 'On page 2 after hitting Page Down' );
+	is($page_comp->view->page_number, 2, 'On page 2 after hitting Page Down' );
 
 	Key_Event($app, Gtk3::Gdk::KEY_Page_Up);
-	is($page_comp->current_page_number, 1, 'On page 1 after hitting Page Up' );
+	is($page_comp->view->page_number, 1, 'On page 1 after hitting Page Up' );
 };
 
 subtest 'Check that up arrow scrolls up and down arrow scrolls down' => CurieTestHelper->run_app_with_document($cairo_doc, sub {

--- a/t/Renard/Curie/Component/MenuBar.t
+++ b/t/Renard/Curie/Component/MenuBar.t
@@ -105,7 +105,7 @@ subtest "Menu: File -> Recent files" => sub {
 
 	$rc->signal_emit('item-activated');
 
-	is path($app->page_document_component->document->filename), $pdf_ref_path, 'File opened from Recent files';
+	is path($app->page_document_component->view->document->filename), $pdf_ref_path, 'File opened from Recent files';
 };
 
 subtest "Menu: View -> Zoom" => sub {

--- a/t/Renard/Curie/Component/MenuBar.t
+++ b/t/Renard/Curie/Component/MenuBar.t
@@ -7,14 +7,13 @@ use CurieTestHelper;
 
 use Renard::Curie::Setup;
 use Renard::Curie::Helper;
-use Gtk3;
+use Renard::Curie::App;
 use URI::file;
 use List::AllUtils qw(first);
 use Test::MockModule;
 use Test::MockObject;
 
 subtest 'Check that the menu item File -> Open exists' => sub {
-	require Renard::Curie::App;
 	my $app = Renard::Curie::App->new;
 
 	my $menu_bar = $app->menu_bar->get_child;

--- a/t/Renard/Curie/Component/MenuBar.t
+++ b/t/Renard/Curie/Component/MenuBar.t
@@ -129,7 +129,7 @@ subtest "Menu: View -> Zoom" => sub {
 	} @menu_item_zoom_levels;
 
 	my $get_zoom_level = sub {
-		$app->page_document_component->zoom_level;
+		$app->page_document_component->view->zoom_level;
 	};
 
 	subtest 'Initial zoom' => sub {

--- a/t/Renard/Curie/Component/Outline.t
+++ b/t/Renard/Curie/Component/Outline.t
@@ -19,7 +19,7 @@ plan tests => 2;
 subtest 'Check that the outline model is set for the current document' => sub {
 	my $app = Renard::Curie::App->new;
 	$app->open_pdf_document( $pdf_ref_path );
-	my $doc = $app->page_document_component->document;
+	my $doc = $app->page_document_component->view->document;
 	my $outline = $doc->outline;
 
 	is( $app->outline->model, $outline->tree_store,
@@ -32,7 +32,7 @@ subtest 'Check that clicking an outline item sets the page number' => sub {
 	my $app = Renard::Curie::App->new;
 	$app->open_pdf_document( $pdf_ref_path );
 	my $page_comp = $app->page_document_component;
-	my $doc = $app->page_document_component->document;
+	my $doc = $app->page_document_component->view->document;
 	my $outline = $doc->outline;
 
 	# start on first page

--- a/t/Renard/Curie/Component/Outline.t
+++ b/t/Renard/Curie/Component/Outline.t
@@ -36,8 +36,8 @@ subtest 'Check that clicking an outline item sets the page number' => sub {
 	my $outline = $doc->outline;
 
 	# start on first page
-	$app->page_document_component->current_page_number(1);
-	is $page_comp->current_page_number, 1, "Start off on the first page";
+	$app->page_document_component->view->page_number(1);
+	is $page_comp->view->page_number, 1, "Start off on the first page";
 
 	my $path_to_second_item = Gtk3::TreePath->new_from_indices(1);
 	my $first_column = $app->outline->tree_view->get_column(0);
@@ -46,7 +46,7 @@ subtest 'Check that clicking an outline item sets the page number' => sub {
 	my $second_outline_item_page = $outline->items->[1]{page};
 
 	is $second_outline_item_page, 9, 'Second outline item page number is 9';
-	is $page_comp->current_page_number, $second_outline_item_page,
+	is $page_comp->view->page_number, $second_outline_item_page,
 		"Activating the second outline row sets the correct page number";
 };
 

--- a/t/Renard/Curie/Component/PageDrawingArea.t
+++ b/t/Renard/Curie/Component/PageDrawingArea.t
@@ -15,16 +15,16 @@ subtest 'Check that moving forward and backward changes the page number' => sub 
 	my $forward_button = $page_comp->builder->get_object('button-forward');
 	my $back_button = $page_comp->builder->get_object('button-back');
 
-	is($page_comp->current_page_number, 1, 'Start on page 1' );
+	is($page_comp->view->page_number, 1, 'Start on page 1' );
 
 	$forward_button->clicked;
-	is($page_comp->current_page_number, 2, 'On page 2 after hitting forward' );
+	is($page_comp->view->page_number, 2, 'On page 2 after hitting forward' );
 
 	$forward_button->clicked;
-	is($page_comp->current_page_number, 3, 'On page 3 after hitting forward' );
+	is($page_comp->view->page_number, 3, 'On page 3 after hitting forward' );
 
 	$back_button->clicked;
-	is($page_comp->current_page_number, 2, 'On page 2 after hitting back' );
+	is($page_comp->view->page_number, 2, 'On page 2 after hitting back' );
 };
 
 subtest 'Check that the first and last buttons work' => sub {
@@ -33,22 +33,22 @@ subtest 'Check that the first and last buttons work' => sub {
 	my $first_button = $page_comp->builder->get_object('button-first');
 	my $last_button = $page_comp->builder->get_object('button-last');
 
-	is($page_comp->current_page_number, 1, 'Start on page 1' );
+	is($page_comp->view->page_number, 1, 'Start on page 1' );
 
 	subtest "Check first button" => sub {
 		$page_comp->view->page_number(3);
-		is $page_comp->current_page_number, 3, "Setting page to 3";
+		is $page_comp->view->page_number, 3, "Setting page to 3";
 
 		$first_button->clicked;
-		is($page_comp->current_page_number, 1, 'On page 1 after hitting first' );
+		is($page_comp->view->page_number, 1, 'On page 1 after hitting first' );
 	};
 
 	subtest "Check last button" => sub {
 		$page_comp->view->page_number(2);
-		is $page_comp->current_page_number, 2, "Setting page to 2";
+		is $page_comp->view->page_number, 2, "Setting page to 2";
 
 		$last_button->clicked;
-		is($page_comp->current_page_number, 4, 'On page 4 after hitting last' );
+		is($page_comp->view->page_number, 4, 'On page 4 after hitting last' );
 	};
 };
 
@@ -61,7 +61,7 @@ subtest 'Check that the current button sensitivity is set on the first and last 
 	my $forward_button = $page_comp->builder->get_object('button-forward');
 	my $back_button = $page_comp->builder->get_object('button-back');
 
-	is($page_comp->current_page_number, 1, 'Start on page 1' );
+	is($page_comp->view->page_number, 1, 'Start on page 1' );
 
 	ok ! $first_button->is_sensitive  , 'button-first is disabled on first page';
 	ok ! $back_button->is_sensitive   , 'button-back is disabled on first page';
@@ -71,7 +71,7 @@ subtest 'Check that the current button sensitivity is set on the first and last 
 	$last_button->clicked;
 	$page_comp->refresh_drawing_area;
 
-	is $page_comp->current_page_number, 4, 'On page 4 after hitting button-last';
+	is $page_comp->view->page_number, 4, 'On page 4 after hitting button-last';
 
 	$page_comp->set_navigation_buttons_sensitivity;
 
@@ -103,11 +103,11 @@ subtest 'Check the page entry' => sub {
 	$entry->set_text('4foo');
 	$entry->signal_emit('activate');
 
-	is $page_comp->current_page_number, 2, "Page number was not changed";
+	is $page_comp->view->page_number, 2, "Page number was not changed";
 
 	$entry->set_text('3');
 	$entry->signal_emit('activate');
-	is $page_comp->current_page_number, 3, "Page number was changed";
+	is $page_comp->view->page_number, 3, "Page number was changed";
 };
 
 subtest 'Page number bound checking' => sub {
@@ -115,19 +115,19 @@ subtest 'Page number bound checking' => sub {
 
 	$page_comp->set_current_page_to_first;
 	$page_comp->set_current_page_back;
-	is $page_comp->current_page_number, 1, "Can not go to previous page when on first page";
+	is $page_comp->view->page_number, 1, "Can not go to previous page when on first page";
 
 	$page_comp->view->page_number(2);
 	$page_comp->set_current_page_back;
-	is $page_comp->current_page_number, 1, "Can move to previous page when on second page";
+	is $page_comp->view->page_number, 1, "Can move to previous page when on second page";
 
 	$page_comp->view->page_number(2);
 	$page_comp->set_current_page_forward;
-	is $page_comp->current_page_number, 3, "Can move to next page when on second page";
+	is $page_comp->view->page_number, 3, "Can move to next page when on second page";
 
 	$page_comp->set_current_page_to_last;
 	$page_comp->set_current_page_forward;
-	is $page_comp->current_page_number, $cairo_doc->last_page_number, "Can not go to next page when on last page";
+	is $page_comp->view->page_number, $cairo_doc->last_page_number, "Can not go to next page when on last page";
 };
 
 done_testing;

--- a/t/Renard/Curie/Component/PageDrawingArea.t
+++ b/t/Renard/Curie/Component/PageDrawingArea.t
@@ -113,20 +113,20 @@ subtest 'Check the page entry' => sub {
 subtest 'Page number bound checking' => sub {
 	my ($app, $page_comp) = CurieTestHelper->create_app_with_document($cairo_doc);
 
-	$page_comp->set_current_page_to_first;
-	$page_comp->set_current_page_back;
+	$page_comp->view->set_current_page_to_first;
+	$page_comp->view->set_current_page_back;
 	is $page_comp->view->page_number, 1, "Can not go to previous page when on first page";
 
 	$page_comp->view->page_number(2);
-	$page_comp->set_current_page_back;
+	$page_comp->view->set_current_page_back;
 	is $page_comp->view->page_number, 1, "Can move to previous page when on second page";
 
 	$page_comp->view->page_number(2);
-	$page_comp->set_current_page_forward;
+	$page_comp->view->set_current_page_forward;
 	is $page_comp->view->page_number, 3, "Can move to next page when on second page";
 
-	$page_comp->set_current_page_to_last;
-	$page_comp->set_current_page_forward;
+	$page_comp->view->set_current_page_to_last;
+	$page_comp->view->set_current_page_forward;
 	is $page_comp->view->page_number, $cairo_doc->last_page_number, "Can not go to next page when on last page";
 };
 

--- a/t/Renard/Curie/Component/PageDrawingArea.t
+++ b/t/Renard/Curie/Component/PageDrawingArea.t
@@ -36,7 +36,7 @@ subtest 'Check that the first and last buttons work' => sub {
 	is($page_comp->current_page_number, 1, 'Start on page 1' );
 
 	subtest "Check first button" => sub {
-		$page_comp->current_page_number(3);
+		$page_comp->view->page_number(3);
 		is $page_comp->current_page_number, 3, "Setting page to 3";
 
 		$first_button->clicked;
@@ -44,7 +44,7 @@ subtest 'Check that the first and last buttons work' => sub {
 	};
 
 	subtest "Check last button" => sub {
-		$page_comp->current_page_number(2);
+		$page_comp->view->page_number(2);
 		is $page_comp->current_page_number, 2, "Setting page to 2";
 
 		$last_button->clicked;
@@ -98,7 +98,7 @@ subtest 'Check the page entry' => sub {
 
 	my $entry = $page_comp->builder->get_object('page-number-entry');
 
-	$page_comp->current_page_number(2);
+	$page_comp->view->page_number(2);
 
 	$entry->set_text('4foo');
 	$entry->signal_emit('activate');
@@ -117,11 +117,11 @@ subtest 'Page number bound checking' => sub {
 	$page_comp->set_current_page_back;
 	is $page_comp->current_page_number, 1, "Can not go to previous page when on first page";
 
-	$page_comp->current_page_number(2);
+	$page_comp->view->page_number(2);
 	$page_comp->set_current_page_back;
 	is $page_comp->current_page_number, 1, "Can move to previous page when on second page";
 
-	$page_comp->current_page_number(2);
+	$page_comp->view->page_number(2);
 	$page_comp->set_current_page_forward;
 	is $page_comp->current_page_number, 3, "Can move to next page when on second page";
 

--- a/t/Renard/Curie/Component/ScrollZoom.t
+++ b/t/Renard/Curie/Component/ScrollZoom.t
@@ -25,11 +25,11 @@ fun Scroll_Event( (InstanceOf['Renard::Curie::App']) $app,
 subtest 'Check that ctrl+scroll-down zooms out of the page' => sub {
 	my ( $app, $page_comp ) = CurieTestHelper->create_app_with_document($cairo_doc);
 
-	ok($page_comp->zoom_level - 1.0 < .001, 'Start at Zoom Level 1.0' );
+	ok($page_comp->view->zoom_level - 1.0 < .001, 'Start at Zoom Level 1.0' );
 
 	Scroll_Event( $app, 'down' );
 
-	ok($page_comp->zoom_level - .95 < .001, 'Reduce Zoom Level to .95');
+	ok($page_comp->view->zoom_level - .95 < .001, 'Reduce Zoom Level to .95');
 
 	$app->window->destroy;
 };
@@ -37,11 +37,11 @@ subtest 'Check that ctrl+scroll-down zooms out of the page' => sub {
 subtest 'Check that ctrl+scroll-up zooms into the page' => sub {
 	my ( $app, $page_comp ) = CurieTestHelper->create_app_with_document($cairo_doc);
 
-	ok($page_comp->zoom_level - 1.0 < .001, 'Start at Zoom Level 1.0' );
+	ok($page_comp->view->zoom_level - 1.0 < .001, 'Start at Zoom Level 1.0' );
 
 	Scroll_Event( $app, 'up' );
 
-	ok($page_comp->zoom_level - 1.05 < .001, 'Reduce Zoom Level to .95');
+	ok($page_comp->view->zoom_level - 1.05 < .001, 'Reduce Zoom Level to .95');
 
 	$app->window->destroy;
 };
@@ -49,11 +49,11 @@ subtest 'Check that ctrl+scroll-up zooms into the page' => sub {
 subtest 'Check that ctrl+smooth-scroll-down zooms out of the page' => sub {
 	my ( $app, $page_comp ) = CurieTestHelper->create_app_with_document($cairo_doc);
 
-	ok($page_comp->zoom_level - 1.0 < .001, 'Start at Zoom Level 1.0' );
+	ok($page_comp->view->zoom_level - 1.0 < .001, 'Start at Zoom Level 1.0' );
 
 	Scroll_Event( $app, 'smooth', -0.05 );
 
-	ok($page_comp->zoom_level - .95 < .001, 'Reduce Zoom Level to .95');
+	ok($page_comp->view->zoom_level - .95 < .001, 'Reduce Zoom Level to .95');
 
 	$app->window->destroy;
 };
@@ -61,11 +61,11 @@ subtest 'Check that ctrl+smooth-scroll-down zooms out of the page' => sub {
 subtest 'Check that ctrl+smooth-scroll-up zooms into the page' => sub {
 	my ( $app, $page_comp ) = CurieTestHelper->create_app_with_document($cairo_doc);
 
-	ok($page_comp->zoom_level - 1.0 < .001, 'Start at Zoom Level 1.0' );
+	ok($page_comp->view->zoom_level - 1.0 < .001, 'Start at Zoom Level 1.0' );
 
 	Scroll_Event( $app, 'smooth', 0.05 );
 
-	ok($page_comp->zoom_level - 1.05 < .001, 'Reduce Zoom Level to .95');
+	ok($page_comp->view->zoom_level - 1.05 < .001, 'Reduce Zoom Level to .95');
 
 	$app->window->destroy;
 };

--- a/t/Renard/Curie/Model/Document/CairoImageSurface.t
+++ b/t/Renard/Curie/Model/Document/CairoImageSurface.t
@@ -20,6 +20,18 @@ subtest 'Cairo document model' => sub {
 	my $first_page = $cairo_doc->get_rendered_page( page_number => 1 );
 	is  $first_page->width, 5000, "Check width of first page";
 	is  $first_page->height, 5000, "Check height of first page";
+
+	cmp_deeply(
+		$cairo_doc->identity_bounds,
+		superbagof({
+			dims  =>  { h => 5000, w =>5000 },
+			pageno => 1,
+			rotate => 0,
+			x      => 5000,
+			y      => 5000,
+		}),
+		'Identity bounds contains correct data'
+	);
 };
 
 

--- a/t/Renard/Curie/Model/Outline.t
+++ b/t/Renard/Curie/Model/Outline.t
@@ -18,14 +18,14 @@ my $pdf_ref_path = try {
 plan tests => 2;
 
 fun print_tree_store($store, $callback) {
-    walk_tree_store($store, fun( $level, $data ) {
-	say "\t"x$level . join ":", @$data;
-    });
+	walk_tree_store($store, fun( $level, $data ) {
+		say "\t"x$level . join ":", @$data;
+	});
 }
 
 fun walk_tree_store($store, $callback) {
-    my $rootiter = $store->get_iter_first();
-    walk_rows($store, $rootiter, 0, $callback);
+	my $rootiter = $store->get_iter_first();
+	walk_rows($store, $rootiter, 0, $callback);
 }
 
 fun walk_rows($store, $treeiter, $level, $callback) {

--- a/t/Renard/Curie/Model/View/ContinuousPage.t
+++ b/t/Renard/Curie/Model/View/ContinuousPage.t
@@ -1,0 +1,47 @@
+#!/usr/bin/env perl
+
+use Test::Most tests => 1;
+
+use lib 't/lib';
+use CurieTestHelper;
+
+use Renard::Curie::Setup;
+use Renard::Curie::App;
+use Renard::Curie::Model::View::ContinuousPage;
+use Renard::Curie::Model::Document::PDF;
+
+subtest "Continuous page" => sub {
+	my $pdf_ref_path = try {
+		CurieTestHelper->test_data_directory->child(qw(PDF Adobe pdf_reference_1-7.pdf));
+	} catch {
+		plan skip_all => "$_";
+	};
+	plan tests => 1;
+
+	my $c = Renard::Curie::Model::View::ContinuousPage->new(
+		document => Renard::Curie::Model::Document::PDF->new( filename => $pdf_ref_path )
+	);
+
+	my $app = Renard::Curie::App->new;
+	$app->page_document_component(
+		Renard::Curie::Component::PageDrawingArea->new(
+			view => $c
+		)
+	);
+	$app->window->show_all;
+
+	Glib::Timeout->add(100, sub {
+		$c->zoom_level(1.1);
+		$c->page_number(2);
+
+		CurieTestHelper->refresh_gui;
+
+		$app->window->destroy;
+
+		pass;
+	});
+
+	$app->main;
+};
+
+done_testing;


### PR DESCRIPTION
See <https://project-renard.github.io/doc/design/interaction/>.

Fixes <https://github.com/project-renard/curie/issues/150>.

---

## Update

So as of right now, we have

- code that can switch between single page view and continuous page views
- both views can handle zooming
- all use of the `document` attribute of the PageDrawingArea have been replaced with a `view` view-model
- a way to send the current scroll position to the view model (but not a way to save it)

I am going to do a bit of moving commits around and merging this once I can get the coverage back up to 100%. Then further work will be done on another branch.

![2017-06-16_19-02-57](https://user-images.githubusercontent.com/94489/27248248-8112a63c-52c6-11e7-93a1-35f2369252ce.gif)
