### PR TITLE
Add `::ExceptionHandler` role to the `::MainWindow` component

### DIFF
--- a/lib/Renard/Curie/Component/MainWindow.pm
+++ b/lib/Renard/Curie/Component/MainWindow.pm
@@ -110,6 +110,7 @@ with qw(
 	Renard::Curie::Component::MainWindow::Role::AccelMap
 	Renard::Curie::Component::MainWindow::Role::MenuBar
 	Renard::Curie::Component::MainWindow::Role::Outline
+	Renard::Curie::Component::MainWindow::Role::ExceptionHandler
 );
 
 1;

--- a/lib/Renard/Curie/Component/MainWindow/Role/ExceptionHandler.pm
+++ b/lib/Renard/Curie/Component/MainWindow/Role/ExceptionHandler.pm
@@ -1,0 +1,73 @@
+use Renard::Curie::Setup;
+package Renard::Curie::Component::MainWindow::Role::ExceptionHandler;
+# ABSTRACT: A role for handling exceptions
+
+use Moo::Role;
+use Gtk3;
+use Glib 'TRUE', 'FALSE';
+
+use constant EXCEPTION_DIALOG_LABEL_MAX_WIDTH_CHARS => 30;
+
+has _exception_handler => (
+	is => 'lazy', # _build__exception_handler
+);
+
+method _build__exception_handler() {
+	Glib->install_exception_handler( fun( $exception ) {
+		if ( $exception->isa('Renard::Curie::Error::User::InvalidPageNumber') ) {
+			$self->_show_exception_dialog_box(
+				'Page number entered is invalid: entered "%s", should be between %s and %s.',
+				[
+					$exception->payload->{text},
+					$exception->payload->{range}[0],
+					$exception->payload->{range}[1],
+				],
+			);
+		} else {
+			$self->_show_exception_dialog_box( "$exception" );
+		}
+
+		return TRUE; # keep the handler
+	});
+};
+
+
+method _show_exception_dialog_box( $message_fmt, $params = [] ) {
+	my $flags = [ qw/modal destroy_with_parent/ ];
+	my $dialog = Gtk3::Dialog->new(
+		"Error",
+		$self->window,
+		$flags,
+		"_Close", 'close',
+	);
+
+	my $hbox = Gtk3::Box->new( 'horizontal', 0 );
+
+	# add image
+	$hbox->add(
+		Gtk3::Image->new_from_icon_name ("dialog-error", 'dialog')
+	);
+
+	# add label
+	my $label = Gtk3::Label->new(
+		sprintf($message_fmt, @$params)
+	);
+	$label->set_line_wrap(TRUE);
+	$label->set_max_width_chars(EXCEPTION_DIALOG_LABEL_MAX_WIDTH_CHARS);
+	$label->set_selectable(TRUE);
+	$hbox->pack_end( $label, TRUE, FALSE, 0 );
+
+	$dialog->get_content_area->pack_start( $hbox, TRUE, TRUE, 0 );
+
+	$dialog->signal_connect( response => sub { $dialog->destroy } );
+
+	$dialog->show_all;
+
+	my $result = $dialog->run;
+}
+
+after setup_window => method() {
+	$self->_exception_handler;
+};
+
+1;

--- a/lib/Renard/Curie/Component/PageDrawingArea.pm
+++ b/lib/Renard/Curie/Component/PageDrawingArea.pm
@@ -382,7 +382,15 @@ callback on_activate_page_number_entry_cb( $entry, $self ) {
 	if( $self->view->document->is_valid_page_number($text) ) {
 		$self->view->page_number( $text );
 	} else {
-		Renard::Curie::Error::User::InvalidPageNumber->throw;
+		Renard::Curie::Error::User::InvalidPageNumber->throw({
+			payload => {
+				text => $text,
+				range => [
+					$self->view->document->first_page_number,
+					$self->view->document->last_page_number
+				],
+			}
+		});
 	}
 }
 

--- a/t/Renard/Curie/Component/PageDrawingArea.t
+++ b/t/Renard/Curie/Component/PageDrawingArea.t
@@ -1,6 +1,7 @@
 #!/usr/bin/env perl
 
 use Test::Most tests => 6;
+use Test::MockModule;
 
 use lib 't/lib';
 use CurieTestHelper;
@@ -102,7 +103,10 @@ subtest 'Check the page entry' => sub {
 	$page_comp->view->page_number(2);
 
 	$entry->set_text('4foo');
+	my $dialog = Test::MockModule->new('Gtk3::Dialog', no_auto => 1);
+	$dialog->mock( run => sub {} ); # do not allow the dialog to be run
 	diag "InvalidPageNumber exception will be thrown - safe to ignore";
+
 	$entry->signal_emit('activate');
 
 	is $page_comp->view->page_number, 2, "Page number was not changed";


### PR DESCRIPTION
This displays a dialog for exceptions that are thrown.

Fixes <https://github.com/project-renard/curie/issues/180>.

Selecting an invalid page number:

![xming_2017-07-01_19-48-49](https://user-images.githubusercontent.com/94489/27766484-c514591c-5e96-11e7-9b71-7666147f8f93.png)

Opening a non-existent filename:
![xming_2017-07-01_19-49-02](https://user-images.githubusercontent.com/94489/27766485-c5151faa-5e96-11e7-99d0-6e19d8a5ee2e.png)


