### PR TITLE
Use method modifiers for setup of PageDrawingArea behavioural roles

### DIFF
--- a/lib/Renard/Curie/Component/PageDrawingArea.pm
+++ b/lib/Renard/Curie/Component/PageDrawingArea.pm
@@ -85,12 +85,7 @@ method BUILD(@) {
 	});
 	$self->set_can_focus( TRUE );
 
-	$self->setup_button_events;
-	$self->setup_text_entry_events;
 	$self->setup_drawing_area;
-	$self->setup_number_of_pages_label;
-	$self->setup_keybindings;
-	$self->setup_scroll_bindings;
 
 	# add as child for this L<Gtk3::Bin>
 	$self->add(

--- a/lib/Renard/Curie/Component/PageDrawingArea/Role/KeyBindings.pm
+++ b/lib/Renard/Curie/Component/PageDrawingArea/Role/KeyBindings.pm
@@ -5,6 +5,10 @@ package Renard::Curie::Component::PageDrawingArea::Role::KeyBindings;
 use Moo::Role;
 use Gtk3;
 
+after BUILD => method(@) {
+	$self->setup_keybindings;
+};
+
 =method setup_keybindings
 
   method setup_keybindings()

--- a/lib/Renard/Curie/Component/PageDrawingArea/Role/MouseScrollBindings.pm
+++ b/lib/Renard/Curie/Component/PageDrawingArea/Role/MouseScrollBindings.pm
@@ -4,6 +4,10 @@ package Renard::Curie::Component::PageDrawingArea::Role::MouseScrollBindings;
 
 use Moo::Role;
 
+after BUILD => method(@) {
+	$self->setup_scroll_bindings;
+};
+
 =method setup_scroll_bindings
 
   method setup_scroll_bindings()

--- a/lib/Renard/Curie/Component/PageDrawingArea/Role/NavigationButtons.pm
+++ b/lib/Renard/Curie/Component/PageDrawingArea/Role/NavigationButtons.pm
@@ -4,6 +4,10 @@ package Renard::Curie::Component::PageDrawingArea::Role::NavigationButtons;
 
 use Moo::Role;
 
+after BUILD => method(@) {
+	$self->setup_button_events;
+};
+
 =method setup_button_events
 
   method setup_button_events()

--- a/lib/Renard/Curie/Component/PageDrawingArea/Role/PageEntry.pm
+++ b/lib/Renard/Curie/Component/PageDrawingArea/Role/PageEntry.pm
@@ -4,6 +4,10 @@ package Renard::Curie::Component::PageDrawingArea::Role::PageEntry;
 
 use Moo::Role;
 
+after BUILD => method(@) {
+	$self->setup_text_entry_events;
+};
+
 =method setup_text_entry_events
 
   method setup_text_entry_events()

--- a/lib/Renard/Curie/Component/PageDrawingArea/Role/PageLabel.pm
+++ b/lib/Renard/Curie/Component/PageDrawingArea/Role/PageLabel.pm
@@ -4,6 +4,10 @@ package Renard::Curie::Component::PageDrawingArea::Role::PageLabel;
 
 use Moo::Role;
 
+after BUILD => method(@) {
+	$self->setup_number_of_pages_label;
+};
+
 =method setup_number_of_pages_label
 
   method setup_number_of_pages_label()


### PR DESCRIPTION
This allows each role to set itself up at construction time.

Fixes <https://github.com/project-renard/curie/issues/219>.


