### PR TITLE
Prevent negative zoom level when zooming out

### DIFF
--- a/lib/Renard/Curie/Component/PageDrawingArea/Role/MouseScrollBindings.pm
+++ b/lib/Renard/Curie/Component/PageDrawingArea/Role/MouseScrollBindings.pm
@@ -4,6 +4,17 @@ package Renard::Curie::Component::PageDrawingArea::Role::MouseScrollBindings;
 
 use Moo::Role;
 
+use Renard::Incunabula::Common::Types qw(ZoomLevel);
+use List::AllUtils qw(max);
+
+=attr MIN_ZOOM_LEVEL
+
+A constant for the minimum zoom level possible so that the zoom level never
+becomes negative.
+
+=cut
+use constant MIN_ZOOM_LEVEL => 0.001;
+
 after BUILD => method(@) {
 	$self->setup_scroll_bindings;
 };
@@ -31,17 +42,39 @@ handlers.
 callback on_scroll_event_cb($window, $event, $self) {
 	if ( $event->state == 'control-mask' && $event->direction eq 'smooth') {
 		my ($delta_x, $delta_y) =  $event->get_scroll_deltas();
-		if ( $delta_y < 0 ) { $self->view_manager->set_zoom_level( $self->view->zoom_level - .05 ); }
-		elsif ( $delta_y > 0 ) { $self->view_manager->set_zoom_level( $self->view->zoom_level + .05 ); }
+		if ( $delta_y < 0 ) { $self->view_manager->set_zoom_level( $self->compute_zoom_out($self->view->zoom_level)  ); }
+		elsif ( $delta_y > 0 ) { $self->view_manager->set_zoom_level( $self->compute_zoom_in($self->view->zoom_level) ); }
 		return 1;
 	} elsif ( $event->state == 'control-mask' && $event->direction eq 'up' ) {
-		$self->view_manager->set_zoom_level( $self->view->zoom_level + .05 );
+		$self->view_manager->set_zoom_level( $self->compute_zoom_in($self->view->zoom_level) );
 		return 1;
 	} elsif ( $event->state == 'control-mask' && $event->direction eq 'down' ) {
-		$self->view_manager->set_zoom_level( $self->view->zoom_level - .05 );
+		$self->view_manager->set_zoom_level( $self->compute_zoom_out($self->view->zoom_level) );
 		return 1;
 	}
 	return 0;
+}
+
+=method compute_zoom_out
+
+  method compute_zoom_out( (ZoomLevel) $zoom_level, $amount = 0.05 )
+
+Computes the new zoom level in order to zoom out.
+
+=cut
+method compute_zoom_out( (ZoomLevel) $zoom_level, $amount = 0.05 ) {
+	return max(MIN_ZOOM_LEVEL, $zoom_level - $amount);
+}
+
+=method compute_zoom_in
+
+  method compute_zoom_in( (ZoomLevel) $zoom_level, $amount = 0.05 ) :ReturnType(ZoomLevel) {
+
+Computes the new zoom level in order to zoom in.
+
+=cut
+method compute_zoom_in( (ZoomLevel) $zoom_level, $amount = 0.05 ) :ReturnType(ZoomLevel) {
+	return $zoom_level + $amount;
 }
 
 1;

--- a/t/Renard/Curie/Component/PageDrawingArea/Role/MouseScrollBindings.t
+++ b/t/Renard/Curie/Component/PageDrawingArea/Role/MouseScrollBindings.t
@@ -1,6 +1,6 @@
 #!/usr/bin/env perl
 
-use Test::Most tests => 4;
+use Test::Most tests => 5;
 
 use lib 't/lib';
 use Renard::Incunabula::Common::Setup;
@@ -70,6 +70,13 @@ subtest 'Check that ctrl+smooth-scroll-up zooms into the page' => sub {
 	ok($page_comp->view->zoom_level - 1.05 < .001, 'Reduce Zoom Level to .95');
 
 	$app->main_window->window->destroy;
+};
+
+subtest 'Check that zooming out does not become negative' => sub {
+	my ( $app, $page_comp ) = CurieTestHelper->create_app_with_document($cairo_doc);
+
+	ok($page_comp->compute_zoom_out(1, 2) > 0,
+		'start at zoom = 100% -> zoom out by 200% is still positive' );
 };
 
 done_testing;


### PR DESCRIPTION

![curie-zoom-scroll-220-prevent-negative-zoom-level-via-mouse-scroll](https://user-images.githubusercontent.com/94489/33373300-dca6e72e-d4c6-11e7-8ff8-d6788bf06c10.gif)


When using the mouse scroll wheel zooming feature, zooming out
(i.e., decrementing the zoom level) can lead to a type check error when
the zoom level becomes negative.

This fixes that by setting a minimum zoom level.

Fixes <https://github.com/project-renard/curie/issues/220>.


