### PR TITLE
PageDrawingArea: Enable scrolling using scroll wheel buttons

### DIFF
--- a/lib/Renard/Curie/Component/PageDrawingArea.pm
+++ b/lib/Renard/Curie/Component/PageDrawingArea.pm
@@ -140,6 +140,8 @@ method setup_drawing_area() {
 		$adjustment->signal_connect( 'changed' => $callback );
 	}
 
+	$drawing_area->add_events('scroll-mask');
+
 	my $vbox = $self->builder->get_object('page-drawing-component');
 	$vbox->pack_start( $scrolled_window, TRUE, TRUE, 0);
 }


### PR DESCRIPTION
This allows scrolling using the mouse wheel scroll button events
generated by older mouse wheels. This is separate from support for
kinetic scrolling often found on newer touchpads — these were already
supported.
