### PR TITLE
Switch from using lsub to MooX::ShortHas

### DIFF
--- a/lib/Renard/Curie/Component/MainWindow.pm
+++ b/lib/Renard/Curie/Component/MainWindow.pm
@@ -12,7 +12,7 @@ use Glib 'TRUE', 'FALSE';
 use Moo 2.001001;
 
 use MooX::Role::Logger ();
-use MooX::Lsub;
+use MooX::ShortHas;
 
 use Renard::Incunabula::Common::Types qw(InstanceOf Path Str);
 use Renard::Incunabula::Document::Types qw(DocumentModel);
@@ -35,11 +35,11 @@ sub _build_loop {
 A L<Gtk3::Window> that contains the main window for the application.
 
 =cut
-lsub window => method() { # :ReturnType(InstanceOf['Gtk3::Window'])
+lazy window => method() {
 	(InstanceOf['Gtk3::Window'])->(
 		$self->builder->get_object('main-window')
 	);
-};
+}, isa => InstanceOf['Gtk3::Window'];
 
 =attr content_box
 
@@ -49,11 +49,11 @@ two different regions.
 The left region contains L</outline> and the right region contains L</page_document_component>.
 
 =cut
-lsub content_box => method() { # :ReturnType(InstanceOf['Gtk3::Box'])
+lazy content_box => method() {
 	(InstanceOf['Gtk3::Box'])->(
 		Gtk3::Box->new( 'horizontal', 0 )
 	);
-};
+}, isa => InstanceOf['Gtk3::Box'];
 
 =method setup_window
 

--- a/lib/Renard/Curie/Component/MainWindow/Role/DragAndDrop.pm
+++ b/lib/Renard/Curie/Component/MainWindow/Role/DragAndDrop.pm
@@ -3,12 +3,12 @@ package Renard::Curie::Component::MainWindow::Role::DragAndDrop;
 # ABSTRACT: Role for drag-and-drop
 
 use Moo::Role;
-use MooX::Lsub;
+use MooX::ShortHas;
 
 use URI::file;
 
-lsub DND_TARGET_URI_LIST => sub { 0 };
-lsub DND_TARGET_TEXT     => sub { 1 };
+lazy DND_TARGET_URI_LIST => sub { 0 };
+lazy DND_TARGET_TEXT     => sub { 1 };
 
 requires 'content_box';
 

--- a/lib/Renard/Curie/Model/ViewOptions/Grid.pm
+++ b/lib/Renard/Curie/Model/ViewOptions/Grid.pm
@@ -3,11 +3,11 @@ package Renard::Curie::Model::ViewOptions::Grid;
 # ABSTRACT: A set of options for grids
 
 use Moo;
-use MooX::Lsub;
-use Renard::Incunabula::Common::Types qw(Maybe PositiveInt);
+use MooX::ShortHas;
+use Renard::Incunabula::Common::Types qw(Maybe PositiveInt Bool);
 use Renard::Curie::Error;
 
-# Need to use the ::BuildArgs version since is_continuous_view is a lsub.
+# Need to use the ::BuildArgs version since is_continuous_view is lazy.
 with qw(MooX::BuildArgs MooX::Role::CloneSet::BuildArgs);
 =for Pod::Coverage
 BUILDARGS FINALIZE_BUILDARGS
@@ -48,10 +48,10 @@ A predicate that returns a true value if the view is a continuous view
 (see C<BUILD>).
 
 =cut
-lsub is_continuous_view => method() {
+lazy is_continuous_view => method() {
 	defined $self->rows xor
 		defined $self->columns;
-};
+}, isa => Bool;
 
 =method BUILD
 


### PR DESCRIPTION
This allows for more concise definitions.

Fixes <https://github.com/project-renard/curie/issues/224>.


