### PR TITLE
Remove explicit GTK+3 dependencies

### DIFF
--- a/maint/devops.yml
+++ b/maint/devops.yml
@@ -2,21 +2,10 @@ native:
   debian:
     packages:
       - pkg-config
-      - libgirepository1.0-dev
-      - gobject-introspection
-      - libgtk-3-dev
-      - gir1.2-gdl-3
       - libexpat1-dev
   macos-homebrew:
-    packages:
-      - gtk+3
-      - clutter-gtk
-      - gtk-mac-integration
-      - gnome-icon-theme
+    packages: ~
   msys2-mingw64:
     packages:
-      - mingw-w64-x86_64-gobject-introspection
-      - mingw-w64-x86_64-cairo
-      - mingw-w64-x86_64-gtk3
       - mingw-w64-x86_64-expat
       - mingw-w64-x86_64-openssl


### PR DESCRIPTION
These are listed in [project-renard/p5-Renard-API-Gtk3](https://github.com/project-renard/p5-Renard-API-Gtk3)
instead.
