### PR TITLE
Scene graph implementation

### DIFF
--- a/lib/Renard/Curie/Model/View/Grid/PageActor.pm
+++ b/lib/Renard/Curie/Model/View/Grid/PageActor.pm
@@ -38,6 +38,7 @@ method render($svg) {
 }
 
 method render_cairo($cr) {
+	return unless $self->{visible};
 	$self->_taffeta->render_cairo( $cr );
 }
 

--- a/lib/Renard/Curie/Model/View/Grid/PageActor.pm
+++ b/lib/Renard/Curie/Model/View/Grid/PageActor.pm
@@ -1,0 +1,28 @@
+package Renard::Curie::Model::View::Grid::PageActor;
+# ABSTRACT: A jacquard actor for a document page
+
+use Mu;
+
+extends qw(Renard::Jacquard::Actor);
+
+has [qw(document page_number)] => (
+	is => 'ro',
+	required => 1,
+);
+
+lazy _rendered_page => method() {
+	$self->document->get_rendered_page(
+		page_number => $self->page_number,
+	);
+};
+
+lazy height => method() { $self->_rendered_page->get_height };
+lazy width => method() { $self->_rendered_page->get_width };
+
+method render($svg) {
+	my $rp = $document->_rendered_page;
+}
+
+with qw(Renard::Jacquard::Role::Geometry::Position2D);
+
+1;

--- a/lib/Renard/Curie/Model/View/Grid/PageActor.pm
+++ b/lib/Renard/Curie/Model/View/Grid/PageActor.pm
@@ -46,6 +46,7 @@ with qw(
 	Renard::Jacquard::Role::Render::QnD::Cairo
 	Renard::Jacquard::Role::Geometry::Position2D
 	Renard::Jacquard::Role::Render::QnD::Size::Direct
+	Renard::Jacquard::Role::Render::QnD::Bounds::Direct
 );
 
 1;

--- a/lib/Renard/Curie/Model/View/Grid/PageActor.pm
+++ b/lib/Renard/Curie/Model/View/Grid/PageActor.pm
@@ -25,20 +25,6 @@ lazy _rendered_page => method() {
 lazy height => method() { $self->_rendered_page->height };
 lazy width => method() { $self->_rendered_page->width };
 
-lazy size => method() {
-	Renard::Yarn::Graphene::Size->new(
-		height => $self->height,
-		width => $self->width,
-	);
-};
-
-lazy bounds => method() {
-	Renard::Yarn::Graphene::Rect->new(
-		origin => $self->origin_point,
-		size => $self->size,
-	);
-};
-
 method render($svg) {
 	my $rp = $self->_rendered_page;
 	my $taffeta = Renard::Taffeta::Graphics::Image::PNG->new(
@@ -48,6 +34,10 @@ method render($svg) {
 	$taffeta->render_svg( $svg );
 }
 
-with qw(Renard::Jacquard::Role::Geometry::Position2D);
+with qw(
+	Renard::Jacquard::Role::Render::QnD::SVG
+	Renard::Jacquard::Role::Geometry::Position2D
+	Renard::Jacquard::Role::Render::QnD::Size::Direct
+);
 
 1;

--- a/lib/Renard/Curie/Model/View/Grid/PageActor.pm
+++ b/lib/Renard/Curie/Model/View/Grid/PageActor.pm
@@ -6,6 +6,8 @@ use Mu;
 use Renard::Block::Format::Cairo::Types qw(RenderableDocumentModel);
 use Renard::Taffeta::Graphics::Image::PNG;
 use Renard::Yarn::Graphene;
+use Renard::Yarn::Types qw(Point Size);
+use List::AllUtils qw(pairmap);
 
 extends qw(Renard::Jacquard::Actor);
 
@@ -40,6 +42,56 @@ method render($svg) {
 method render_cairo($cr) {
 	return unless $self->{visible};
 	$self->_taffeta->render_cairo( $cr );
+}
+
+lazy _textual_page => method() {
+	my $tp = $self->document->get_textual_page(
+		$self->page_number,
+	);
+
+	$tp;
+};
+
+method text_at_point( (Point) $point) {
+	my $tp = $self->_textual_page;
+
+	my $page_transform = Renard::Yarn::Graphene::Matrix->new;
+	$page_transform->init_from_2d( 1, 0 , 0 , 1,
+		$self->x->value,
+		$self->y->value );
+
+	my $bbox_to_rect = sub {
+		my ($bbox) = @_;
+		my ($x0, $y0, $x1, $y1) = split ' ', $bbox;
+		$page_transform->transform_bounds(
+			Renard::Yarn::Graphene::Rect->new(
+				origin => Point->coerce([$x0, $y0]),
+				size => Size->coerce([$x1-$x0, $y1-$y0]),
+			)
+		);
+	};
+	my $m_quad_to_g_quad = sub {
+		my ($quad) = @_;
+		my @points = pairmap { Point->coerce([$a, $b]) } split ' ', $quad;
+		$page_transform->transform_quad(
+			Renard::Yarn::Graphene::Quad->alloc->init_from_points( \@points )
+		);
+	};
+
+	my @blocks;
+	$tp->iter_extents( sub {
+		my ($extent, $tag_name, $tag_value) = @_;
+		my $g_bbox = $bbox_to_rect->($tag_value->{bbox});
+		push @blocks, {
+			extent => $extent,
+			tag => $tag_name,
+			bbox => $g_bbox,
+		} if $g_bbox->contains_point( $point );
+	}, only => ['block'] );
+
+	if( @blocks ) {
+		return $blocks[0];
+	}
 }
 
 with qw(

--- a/lib/Renard/Curie/Model/View/Grid/PageActor.pm
+++ b/lib/Renard/Curie/Model/View/Grid/PageActor.pm
@@ -25,17 +25,25 @@ lazy _rendered_page => method() {
 lazy height => method() { $self->_rendered_page->height };
 lazy width => method() { $self->_rendered_page->width };
 
-method render($svg) {
+lazy _taffeta => method() {
 	my $rp = $self->_rendered_page;
 	my $taffeta = Renard::Taffeta::Graphics::Image::PNG->new(
 		data => $rp->png_data,
 		origin => $self->origin_point,
 	);
-	$taffeta->render_svg( $svg );
+};
+
+method render($svg) {
+	$self->_taffeta->render_svg( $svg );
+}
+
+method render_cairo($cr) {
+	$self->_taffeta->render_cairo( $cr );
 }
 
 with qw(
 	Renard::Jacquard::Role::Render::QnD::SVG
+	Renard::Jacquard::Role::Render::QnD::Cairo
 	Renard::Jacquard::Role::Geometry::Position2D
 	Renard::Jacquard::Role::Render::QnD::Size::Direct
 );

--- a/lib/Renard/Curie/Model/View/Grid/PageActor.pm
+++ b/lib/Renard/Curie/Model/View/Grid/PageActor.pm
@@ -1,14 +1,20 @@
+use Renard::Incunabula::Common::Setup;
 package Renard::Curie::Model::View::Grid::PageActor;
 # ABSTRACT: A jacquard actor for a document page
 
 use Mu;
+use Renard::Block::Format::Cairo::Types qw(RenderableDocumentModel);
+use Renard::Taffeta::Graphics::Image::PNG;
+use Renard::Yarn::Graphene;
 
 extends qw(Renard::Jacquard::Actor);
 
-has [qw(document page_number)] => (
-	is => 'ro',
-	required => 1,
+ro document => (
+	isa => RenderableDocumentModel,
 );
+
+ro 'page_number';
+
 
 lazy _rendered_page => method() {
 	$self->document->get_rendered_page(
@@ -16,11 +22,30 @@ lazy _rendered_page => method() {
 	);
 };
 
-lazy height => method() { $self->_rendered_page->get_height };
-lazy width => method() { $self->_rendered_page->get_width };
+lazy height => method() { $self->_rendered_page->height };
+lazy width => method() { $self->_rendered_page->width };
+
+lazy size => method() {
+	Renard::Yarn::Graphene::Size->new(
+		height => $self->height,
+		width => $self->width,
+	);
+};
+
+lazy bounds => method() {
+	Renard::Yarn::Graphene::Rect->new(
+		origin => $self->origin_point,
+		size => $self->size,
+	);
+};
 
 method render($svg) {
-	my $rp = $document->_rendered_page;
+	my $rp = $self->_rendered_page;
+	my $taffeta = Renard::Taffeta::Graphics::Image::PNG->new(
+		data => $rp->png_data,
+		origin => $self->origin_point,
+	);
+	$taffeta->render_svg( $svg );
 }
 
 with qw(Renard::Jacquard::Role::Geometry::Position2D);

--- a/maint/cpanfile-git
+++ b/maint/cpanfile-git
@@ -13,3 +13,6 @@ requires 'Renard::Block::NLP',
 requires 'Renard::Jacquard',
 	git => 'https://github.com/project-renard/p5-Renard-Jacquard.git',
 	branch => 'layout-punchcard';
+requires 'Renard::Taffeta',
+	git => 'https://github.com/project-renard/p5-Renard-Taffeta.git',
+	branch => 'cairo-transform-matrix';

--- a/maint/cpanfile-git
+++ b/maint/cpanfile-git
@@ -10,3 +10,6 @@ requires 'Renard::API::Gtk3',
 requires 'Renard::Block::NLP',
 	git => 'https://github.com/project-renard/p5-Renard-Block-NLP.git',
 	branch => 'master';
+requires 'Renard::Jacquard',
+	git => 'https://github.com/project-renard/p5-Renard-Jacquard.git',
+	branch => 'layout-punchcard';

--- a/t-grid.pl
+++ b/t-grid.pl
@@ -16,6 +16,7 @@ use Path::Tiny;
 
 use Renard::API::Cairo;
 use Gtk3 -init;
+use Glib qw(TRUE FALSE);
 
 use Devel::Timer;
 
@@ -159,8 +160,10 @@ sub do_gtk_things {
 	$window->signal_connect( destroy => sub { Gtk3::main_quit } );
 	$window->set_default_size(800, 600);
 
+	my $vbox = Gtk3::Box->new( 'vertical', 0 );
+	$window->add( $vbox );
+
 	my $scrolled = Gtk3::ScrolledWindow->new;
-	$window->add($scrolled);
 	$data->{scroll} = $scrolled;
 
 	my $drawing_area = Gtk3::DrawingArea->new;
@@ -170,6 +173,11 @@ sub do_gtk_things {
 	);
 	$drawing_area->signal_connect( draw => \&cb_on_draw, $data );
 	$scrolled->add($drawing_area);
+
+	my $status_bar = Gtk3::Statusbar->new;
+
+	$vbox->pack_start($scrolled, TRUE, TRUE, 0 );
+	$vbox->pack_end($status_bar, FALSE, FALSE, 0);
 
 	$window->show_all;
 	Gtk3::main;

--- a/t-grid.pl
+++ b/t-grid.pl
@@ -8,6 +8,7 @@ use lib "$FindBin::Bin/../lib";
 use Modern::Perl;
 use Renard::Block::Format::PDF::Document;
 use Renard::Curie::Model::View::Grid::PageActor;
+use Renard::Jacquard::Layout::Grid;
 use Path::Tiny;
 
 sub main {
@@ -15,13 +16,41 @@ sub main {
 		filename => path('~/Downloads/Anatomy Shelf Notes copy.pdf'),
 	);
 
-	my $actor = Renard::Curie::Model::View::Grid::PageActor->new(
-		document => $document,
-		page_number => 1,
+	my $_LayoutGroup = Moo::Role->create_class_with_roles(
+		'Renard::Jacquard::Actor' => qw(
+		Renard::Jacquard::Role::Geometry::Position2D
+		Renard::Jacquard::Role::Render::QnD::SVG::Group
+		Renard::Jacquard::Role::Render::QnD::Layout::Grid
+		Renard::Jacquard::Role::Render::QnD::Bounds::Group
+	));
+	my $group = $_LayoutGroup->new(
+		layout => Renard::Jacquard::Layout::Grid->new( rows => 3, columns => 2 ),
 	);
-	use DDP; p $actor;
 
-	require Carp::REPL; Carp::REPL->import('repl'); repl();#DEBUG
+	for my $page_no (1..6) {
+		my $actor = Renard::Curie::Model::View::Grid::PageActor->new(
+			document => $document,
+			page_number => $page_no,
+		);
+		$group->add_child( $actor );
+	}
+
+	$group->x->value( 0 );
+	$group->y->value( 0 );
+	$group->update_layout;
+	my $bounds = $group->bounds;
+
+	my $svg = SVG->new;
+	$group->render($svg);
+
+	$svg->{-childs}[0]->setAttribute('height', $bounds->size->height);
+	$svg->{-childs}[0]->setAttribute('width', $bounds->size->width);
+	my $svg_file = path('a.svg');
+	$svg_file->spew_utf8( $svg->xmlify );
+	use Browser::Open qw(open_browser);
+	open_browser($svg_file);
+
+	#require Carp::REPL; Carp::REPL->import('repl'); repl();#DEBUG
 }
 
 main;

--- a/t-grid.pl
+++ b/t-grid.pl
@@ -294,7 +294,7 @@ package JacquardCanvas {
 		};
 
 		my $matrix = Renard::Yarn::Graphene::Matrix->new;
-		$matrix->init_scale($self->{scale}, $self->{scale}, 0);
+		$matrix->init_scale($self->{scale}, $self->{scale}, 1);
 		$vp_is_visible->($self->{sg}, $matrix);
 
 		$self->{views} = \@views;
@@ -345,6 +345,7 @@ sub do_gtk_things {
 	my $data = {};
 
 	$data->{scale} = 0.3;
+	$data->{scale} //= 1.0;
 
 	$data->{sg} = create_scene_graph;
 	update_layout( $data->{sg} );

--- a/t-grid.pl
+++ b/t-grid.pl
@@ -175,7 +175,12 @@ sub cb_on_scroll {
 	my $vp_is_visible = sub {
 		my ($g, $g_matrix) = @_;
 		my $t_matrix = Renard::Yarn::Graphene::Matrix->new;
-		$t_matrix->init_from_2d( 1, 0 , 0 , 1, $g->x->value, $g->y->value );
+		if( $g->does('Renard::Jacquard::Role::Render::QnD::Layout') ) {
+			$t_matrix->init_from_2d( 1, 0 , 0 , 1, $g->x->value, $g->y->value );
+		} else {
+			# position translation is already incorporated into bounds of non-layout
+			$t_matrix->init_from_2d( 1, 0 , 0 , 1, 0, 0 );
+		}
 		my $matrix = $t_matrix x $g_matrix;
 		if( $g->isa('Renard::Curie::Model::View::Grid::PageActor') &&
 			( $matrix->transform_bounds($g->bounds)->intersection($vp_bounds) )[0]

--- a/t-grid.pl
+++ b/t-grid.pl
@@ -1,0 +1,27 @@
+#!/usr/bin/env perl
+# PODNAME: t-grid.pl
+# ABSTRACT: do some messy stutff
+
+use FindBin;
+use lib "$FindBin::Bin/../lib";
+
+use Modern::Perl;
+use Renard::Block::Format::PDF::Document;
+use Renard::Curie::Model::View::Grid::PageActor;
+use Path::Tiny;
+
+sub main {
+	my $document = Renard::Block::Format::PDF::Document->new(
+		filename => path('~/Downloads/Anatomy Shelf Notes copy.pdf'),
+	);
+
+	my $actor = Renard::Curie::Model::View::Grid::PageActor->new(
+		document => $document,
+		page_number => 1,
+	);
+	use DDP; p $actor;
+
+	require Carp::REPL; Carp::REPL->import('repl'); repl();#DEBUG
+}
+
+main;

--- a/t-grid.pl
+++ b/t-grid.pl
@@ -92,7 +92,7 @@ sub update_layout {
 	my ($group) = @_;
 	$t->mark('Updating layouts');
 	_update_layouts($group);
-	say "done";
+	$t->mark('Done updating layouts');
 }
 
 sub render_to_svg {

--- a/t-grid.pl
+++ b/t-grid.pl
@@ -217,7 +217,34 @@ package JacquardCanvas {
 
 		$self->signal_connect( draw => \&cb_on_draw );
 
+		$self->signal_connect(
+			'motion-notify-event' => sub {
+				my ($widget, $event) = @_;
+				my $event_point = Point->coerce([ $event->x, $event->y ]);
+
+				my ($h, $v) = (
+					$self->get_hadjustment,
+					$self->get_vadjustment,
+				);
+				my $matrix = Renard::Yarn::Graphene::Matrix->new;
+				$matrix->init_from_2d( 1, 0 , 0 , 1, $h->get_value, $v->get_value );
+
+				my $point = $matrix * $event_point;
+				my @pages = map {
+					$self->{bounds}->[$_]->contains_point($point)
+					? $self->{pages}->[$_]
+					: ();
+				} 0..scalar @{ $self->{pages} } - 1;
+				if( @pages) {
+					$self->set_tooltip_text("@pages");
+				} else {
+					$self->set_has_tooltip(FALSE);
+				}
+			}
+		);
+
 		$self->add_events('scroll-mask');
+		$self->add_events('pointer-motion-mask');
 
 		$self;
 	}

--- a/t-grid.pl
+++ b/t-grid.pl
@@ -273,9 +273,17 @@ package JacquardCanvas {
 								$bounds
 						) for @$data;
 
+						if( $data->[-1]{tag} eq 'char' ) {
+							$self->_set_cursor_to_name('text');
+						} else {
+							$self->_set_cursor_to_name('default');
+						}
+
 						$self->signal_emit( 'text-found' );
 					} else {
 						delete $self->{text};
+
+						$self->_set_cursor_to_name('default');
 					}
 					$self->queue_draw;
 				}
@@ -286,6 +294,13 @@ package JacquardCanvas {
 		$self->add_events('pointer-motion-mask');
 
 		$self;
+	}
+
+	sub _set_cursor_to_name {
+		my ($self, $name) = @_;
+		$self->get_window->set_cursor(
+			Gtk3::Gdk::Cursor->new_from_name($self->get_display, $name)
+		);
 	}
 
 	sub cb_on_scroll {

--- a/t-grid.pl
+++ b/t-grid.pl
@@ -6,38 +6,74 @@ use FindBin;
 use lib "$FindBin::Bin/../lib";
 
 use Modern::Perl;
+use Renard::Incunabula::Common::Setup;
+use feature qw(current_sub);
 use Renard::Block::Format::PDF::Document;
 use Renard::Curie::Model::View::Grid::PageActor;
 use Renard::Jacquard::Layout::Grid;
+use Renard::Jacquard::Layout::Box;
 use Path::Tiny;
 
-sub main {
-	my $document = Renard::Block::Format::PDF::Document->new(
-		filename => path('~/Downloads/Anatomy Shelf Notes copy.pdf'),
-	);
+use constant BOX_LAYOUT => 1;
 
-	my $_LayoutGroup = Moo::Role->create_class_with_roles(
-		'Renard::Jacquard::Actor' => qw(
-		Renard::Jacquard::Role::Geometry::Position2D
-		Renard::Jacquard::Role::Render::QnD::SVG::Group
-		Renard::Jacquard::Role::Render::QnD::Layout::Grid
-		Renard::Jacquard::Role::Render::QnD::Bounds::Group
-	));
+my $document = Renard::Block::Format::PDF::Document->new(
+	filename => path('~/Downloads/Anatomy Shelf Notes copy.pdf'),
+);
+
+my $_LayoutGroup = Moo::Role->create_class_with_roles(
+	'Renard::Jacquard::Actor' => qw(
+	Renard::Jacquard::Role::Geometry::Position2D
+	Renard::Jacquard::Role::Geometry::Size2D
+	Renard::Jacquard::Role::Render::QnD::SVG::Group
+	Renard::Jacquard::Role::Render::QnD::Layout
+	Renard::Jacquard::Role::Render::QnD::Size::Direct
+	Renard::Jacquard::Role::Render::QnD::Bounds::Direct
+));
+
+fun create_group( :$start, :$end, :$margin = 10 ) {
 	my $group = $_LayoutGroup->new(
 		layout => Renard::Jacquard::Layout::Grid->new( rows => 3, columns => 2 ),
 	);
 
-	for my $page_no (1..6) {
+	for my $page_no ($start..$end) {
 		my $actor = Renard::Curie::Model::View::Grid::PageActor->new(
 			document => $document,
 			page_number => $page_no,
 		);
-		$group->add_child( $actor );
+		if( BOX_LAYOUT ) {
+			my $box = $_LayoutGroup->new(
+				layout => Renard::Jacquard::Layout::Box->new( margin => $margin ),
+			);
+			$box->add_child( $actor );
+			$group->add_child( $box );
+		} else {
+			$group->add_child( $actor );
+		}
 	}
+
+	$group;
+}
+
+sub main {
+	my $group = $_LayoutGroup->new(
+		layout => Renard::Jacquard::Layout::Grid->new( rows => 2, columns => 2 ),
+	);
+
+	$group->add_child( create_group(start => 1, end => 6,   margin => 10) );
+	$group->add_child( create_group(start => 7, end => 12,  margin => 50) );
+	$group->add_child( create_group(start => 13, end => 18, margin => 100) );
+	$group->add_child( create_group(start => 19, end => 24, margin => 150) );
 
 	$group->x->value( 0 );
 	$group->y->value( 0 );
-	$group->update_layout;
+
+	sub update_layouts {
+		my ($g) = @_;
+		__SUB__->($_) for @{ $g->children };
+		$g->update_layout if $g->can('update_layout');
+	};
+	update_layouts($group);
+
 	my $bounds = $group->bounds;
 
 	my $svg = SVG->new;


### PR DESCRIPTION
Connects with: <https://github.com/Intertangle/p5-Renard-Jacquard/pull/4>, <https://github.com/Intertangle/p5-Renard-Punchcard/pull/2>.

Steps for prototype:
- [x] Draw PDF pages to SVG.
- [x] Draw PDF pages as grid to SVG.
- [x] Draw PDF pages with box layout (margins around pages) to SVG.
- [x] Draw PDF pages as `Grid[Grid[Box[Page]]]` layout to SVG.
- [x] Draw PDF pages to Cairo surface (with Cairo surface size as big as all the pages).
- [x] Show which pages are visible in view-port of Cairo surface.
- [x] Draw PDF pages to Cairo surface (with Cairo surface the size of viewport).
- [x] Show page under cursor on hover.
- [x] Change cursor to [I-beam pointer](https://en.wikipedia.org/wiki/Cursor_(user_interface)#I-beam_pointer) when over text.
<del>

- [ ] Select text via mouse drag under cursor for single page.
- [ ] Select text via mouse drag under cursor across page boundaries.
- [ ] Implement changing № of columns for grid displayed on Cairo surface.
- [ ] Implement continuous / non-continuous view while keeping previous features.
- [ ] Implement zooming while keeping previous features.

</del>