### PR TITLE
Scene graph implementation (continued)

### DIFF
--- a/lib/Renard/Curie/Model/View/Grid/PageActor.pm
+++ b/lib/Renard/Curie/Model/View/Grid/PageActor.pm
@@ -60,8 +60,7 @@ lazy _page_transform => method() {
 	$page_transform;
 };
 
-sub _bbox_to_rect {
-	my ($self, $bbox) = @_;
+method _bbox_to_rect($bbox) {
 	my ($x0, $y0, $x1, $y1) = split ' ', $bbox;
 	$self->_page_transform->transform_bounds(
 		Renard::Yarn::Graphene::Rect->new(
@@ -71,8 +70,7 @@ sub _bbox_to_rect {
 	);
 }
 
-sub _m_quad_to_rect {
-	my ($self, $quad) = @_;
+method _m_quad_to_rect($quad) {
 	my @points = pairmap { Point->coerce([$a, $b]) } split ' ', $quad;
 	$self->_page_transform->transform_bounds(
 		Renard::Yarn::Graphene::Quad->alloc

--- a/lib/Renard/Curie/Model/View/Grid/PageActor.pm
+++ b/lib/Renard/Curie/Model/View/Grid/PageActor.pm
@@ -79,6 +79,15 @@ method _m_quad_to_rect($quad) {
 	);
 }
 
+method _compute_bbox_for_tag_value($tag_value) {
+	if( exists $tag_value->{g_bbox} ) {
+		return $tag_value->{g_bbox};
+	}
+	return $tag_value->{g_bbox} = exists $tag_value->{bbox}
+		? $self->_bbox_to_rect($tag_value->{bbox})
+		: $self->_m_quad_to_rect($tag_value->{quad});
+}
+
 method text_at_point( (Point) $point) {
 	my $tp = $self->_textual_page;
 
@@ -91,9 +100,7 @@ method text_at_point( (Point) $point) {
 		my @gather;
 		$tp->iter_extents( sub {
 				my ($extent, $tag_name, $tag_value) = @_;
-				my $g_bbox = exists $tag_value->{bbox}
-					? $self->_bbox_to_rect($tag_value->{bbox})
-					: $self->_m_quad_to_rect($tag_value->{quad});
+				my $g_bbox = $self->_compute_bbox_for_tag_value($tag_value);
 				push @gather, {
 					extent => $extent,
 					tag => $tag_name,

--- a/t-grid.pl
+++ b/t-grid.pl
@@ -494,24 +494,25 @@ package JacquardCanvas {
 		}
 
 		my $text_data = $self->_get_text_data_for_pointer($pointer_data);
-		if( defined $text_data && @$text_data ) {
-			my $block = $text_data->[0];
-			$self->{text}{substr} = $block->{extent}->substr;
-			$self->{text}{data} = $block;
+		if( defined $text_data ) {
+			if( @$text_data ) {
+				my $block = $text_data->[0];
+				$self->{text}{substr} = $block->{extent}->substr;
+				$self->{text}{data} = $block;
 
-			$self->{text}{layers} = $text_data;
+				$self->{text}{layers} = $text_data;
 
-			if( $text_data->[-1]{tag} eq 'char' ) {
-				$self->_set_cursor_to_name('text');
+				if( $text_data->[-1]{tag} eq 'char' ) {
+					$self->_set_cursor_to_name('text');
+				} else {
+					$self->_set_cursor_to_name('default');
+				}
+
+				$self->signal_emit( 'text-found' );
 			} else {
+				delete $self->{text};
 				$self->_set_cursor_to_name('default');
 			}
-
-			$self->signal_emit( 'text-found' );
-			$self->queue_draw;
-		} else {
-			delete $self->{text};
-			$self->_set_cursor_to_name('default');
 			$self->queue_draw;
 		}
 

--- a/t-grid.pl
+++ b/t-grid.pl
@@ -228,9 +228,15 @@ package JacquardCanvas {
 			'motion-notify-event' => \&cb_on_motion_notify,
 			$self
 		);
+		$self->signal_connect( 'button-press-event' => \&cb_on_button_press_event, $self );
+		$self->signal_connect( 'button-release-event' => \&cb_on_button_release_event, $self );
 
 		$self->add_events('scroll-mask');
-		$self->add_events('pointer-motion-mask');
+		$self->add_events([qw/
+			pointer-motion-mask
+			button-press-mask
+			button-release-mask
+		/]);
 
 		$self;
 	}
@@ -348,6 +354,28 @@ package JacquardCanvas {
 	}
 
 
+	sub cb_on_button_press_event {
+		my ($widget, $event, $self) = @_;
+
+		if( $event->state & 'button1-mask' ) {
+			say "Start selection";
+			...;
+		}
+
+		return TRUE;
+	}
+
+	sub cb_on_button_release_event {
+		my ($widget, $event, $self) = @_;
+
+		if( $event->state & 'button1-mask' ) {
+			say "End selection";
+			...;
+		}
+
+		return TRUE;
+	}
+
 	sub cb_on_motion_notify {
 		my ($widget, $event, $self) = @_;
 
@@ -360,6 +388,12 @@ package JacquardCanvas {
 
 	sub cb_on_motion_notify_button1 {
 		my ($widget, $event, $self) = @_;
+
+		if( $event->state & 'button1-mask' ) {
+			say "Continuing selection";
+			...;
+		}
+
 		return TRUE;
 	}
 

--- a/t-grid.pl
+++ b/t-grid.pl
@@ -535,6 +535,7 @@ sub do_gtk_things {
 	my $window = Gtk3::Window->new('toplevel');
 	$window->signal_connect( destroy => sub { Gtk3::main_quit } );
 	$window->set_default_size(800, 600);
+	$window->set_position('center');
 
 	my $vbox = Gtk3::Box->new( 'vertical', 0 );
 	$window->add( $vbox );

--- a/t-grid.pl
+++ b/t-grid.pl
@@ -324,12 +324,7 @@ package JacquardCanvas {
 		if( HIGHLIGHT_LAYERS && exists $self->{text} ) {
 			for my $layer (@{ $self->{text}{layers} }) {
 				my $bounds = $layer->{t_bbox};
-				$cr->rectangle(
-					$bounds->get_x - $h->get_value,
-					$bounds->get_y - $v->get_value,
-					$bounds->get_width,
-					$bounds->get_height,
-				);
+				$self->_draw_bounds_as_rectangle($cr, $bounds);
 				$cr->set_source_rgba(0, 0, 0, 0.5);
 				$cr->set_line_width(1);
 				$cr->stroke_preserve;
@@ -341,16 +336,27 @@ package JacquardCanvas {
 		if( HIGHLIGHT_BOUNDS ) {
 			#say "Drawing # of bounds: @{[ scalar @{ $self->{views} } ]}";
 			for my $bounds (map { $_->{bounds} } @{ $self->{views} }) {
-				$cr->rectangle(
-					$bounds->get_x - $h->get_value,
-					$bounds->get_y - $v->get_value,
-					$bounds->get_width,
-					$bounds->get_height,
-				);
+				$self->_draw_bounds_as_rectangle($cr, $bounds);
 				$cr->set_source_rgba(1, 0, 0, 0.2);
 				$cr->fill;
 			}
 		}
+	}
+
+	sub _draw_bounds_as_rectangle {
+		my ($self, $cr, $bounds) = @_;
+
+		my ($h, $v) = (
+			$self->get_hadjustment,
+			$self->get_vadjustment,
+		);
+
+		$cr->rectangle(
+			$bounds->get_x - $h->get_value,
+			$bounds->get_y - $v->get_value,
+			$bounds->get_width,
+			$bounds->get_height,
+		);
 	}
 
 

--- a/t-grid.pl
+++ b/t-grid.pl
@@ -175,6 +175,7 @@ package JacquardCanvas {
 	use Renard::Yarn::Types qw(Point Size);
 
 	use constant HIGHLIGHT_BOUNDS => $ENV{T_GRID_HIGHLIGHT_BOUNDS} // 0;
+	use constant HIGHLIGHT_LAYERS => $ENV{T_GRID_HIGHLIGHT_LAYERS} // 0;
 
 	sub new {
 		my ($class, %args) = @_;
@@ -376,7 +377,7 @@ package JacquardCanvas {
 		$cr->restore;
 
 
-		if( exists $self->{text} ) {
+		if( HIGHLIGHT_LAYERS && exists $self->{text} ) {
 			for my $layer (@{ $self->{text}{layers} }) {
 				my $bounds = $layer->{t_bbox};
 				$cr->rectangle(

--- a/t-grid.pl
+++ b/t-grid.pl
@@ -437,7 +437,7 @@ package JacquardCanvas {
 	sub cb_on_button_press_event {
 		my ($widget, $event, $self) = @_;
 
-		if( $event->state & 'button1-mask' ) {
+		if( $event->button == Gtk3::Gdk::BUTTON_PRIMARY ) {
 			say "Start selection";
 			...;
 		}

--- a/t-grid.pl
+++ b/t-grid.pl
@@ -359,7 +359,7 @@ package JacquardCanvas {
 		$cr->restore;
 
 
-		if( HIGHLIGHT_LAYERS && exists $self->{text} ) {
+		if( HIGHLIGHT_LAYERS() && exists $self->{text} ) {
 			for my $layer (@{ $self->{text}{layers} }) {
 				my $bounds = $layer->{t_bbox};
 				$self->_draw_bounds_as_rectangle($cr, $bounds);
@@ -371,7 +371,7 @@ package JacquardCanvas {
 			}
 		}
 
-		if( HIGHLIGHT_BOUNDS ) {
+		if( HIGHLIGHT_BOUNDS() ) {
 			#say "Drawing # of bounds: @{[ scalar @{ $self->{views} } ]}";
 			for my $bounds (map { $_->{bounds} } @{ $self->{views} }) {
 				$self->_draw_bounds_as_rectangle($cr, $bounds);


### PR DESCRIPTION
Connects with: <https://github.com/Intertangle/p5-Renard-Jacquard/pull/4>, <https://github.com/Intertangle/p5-Renard-Punchcard/pull/2>, <https://github.com/Intertangle/p5-Renard-Taffeta/pull/4>

Continued from <https://github.com/project-renard/curie/pull/237>.

Steps for prototype:
- [x] Select text via mouse drag under cursor for single page.
- [x] Select text via mouse drag under cursor across page boundaries.

<del>

- [ ] Implement changing № of columns for grid displayed on Cairo surface.
- [ ] Implement continuous / non-continuous view while keeping previous features.
- [ ] Implement zooming while keeping previous features.

</del>